### PR TITLE
drop zero length query fields

### DIFF
--- a/intake_esgf/catalog.py
+++ b/intake_esgf/catalog.py
@@ -190,6 +190,13 @@ class ESGFCatalog:
                 return pd.DataFrame([])
             return df
 
+        # drop empty search fields
+        search = {
+            k: v
+            for k, v in search.items()
+            if (isinstance(v, str) and len(v) > 0) or not isinstance(v, str)
+        }
+
         # log what is being searched for
         search_str = ", ".join(
             [

--- a/intake_esgf/core/globus.py
+++ b/intake_esgf/core/globus.py
@@ -64,7 +64,6 @@ class GlobusESGFIndex:
 
         # build up the query and search
         query_data = SearchQuery("")
-        search = {k: v for k, v in search.items() if len(v) > 0}
         for key, val in search.items():
             query_data.add_filter(
                 key, val if isinstance(val, list) else [val], type="match_any"

--- a/intake_esgf/core/globus.py
+++ b/intake_esgf/core/globus.py
@@ -64,6 +64,7 @@ class GlobusESGFIndex:
 
         # build up the query and search
         query_data = SearchQuery("")
+        search = {k: v for k, v in search.items() if len(v) > 0}
         for key, val in search.items():
             query_data.add_filter(
                 key, val if isinstance(val, list) else [val], type="match_any"


### PR DESCRIPTION
This PR enables running the following query with a zero length field entry:

```python
cat.search(
    experiment_id="historical",
    source_id="CanESM5",
    frequency="mon",
    variable_id=["gpp", "tas", "pr"],
    variant_label="",
)
```