### PR TITLE
ADD: more project-agnostic (CMIP3 and CMIP5 tested)

### DIFF
--- a/intake_esgf/base.py
+++ b/intake_esgf/base.py
@@ -451,4 +451,6 @@ def get_content_path(content: dict[str, Any]) -> Path:
     match = re.search(rf".*({project.lower()}.*.nc)|.*", urls[0])
     if not match:
         raise ValueError(f"Could not parse out the path from {urls[0]}")
-    return Path(match.group(1))
+    # try to fix records with case-insensitive paths
+    path = match.group(1).replace(project.lower(), project)
+    return Path(path)

--- a/intake_esgf/base.py
+++ b/intake_esgf/base.py
@@ -346,7 +346,7 @@ def get_dataframe_columns(content: dict[str, Any]) -> list[str]:
     """
 
     # CMIP5 is a disaster so...
-    if "project" in content and content["project"] == "CMIP5":
+    if "project" in content and content["project"][0] == "CMIP5":
         return [
             "institute",
             "model",

--- a/intake_esgf/base.py
+++ b/intake_esgf/base.py
@@ -412,3 +412,43 @@ def get_facet_by_type(
             f"Ambiguous '{ftype}' facet in {list(df.columns)}, found {facet}"
         )
     return facet[0]
+
+
+def get_content_path(content: dict[str, Any]) -> Path:
+    """Get the local path where the data is to be stored.
+
+    In CMIP6 we get a directory template, we just fill in values from the content. In
+    older projects we do not, but can search for the project name and grab all the text
+    following it. In the end, as long as we are consistent it does not matter.
+
+    """
+
+    def _form_from_template(content) -> Path:
+        template = re.findall(r"%\((\w+)\)s", content["directory_format_template_"][0])
+        template = [
+            content[t][0] if isinstance(content[t], list) else content[t]
+            for t in template
+            if t in content
+        ]
+        return Path("/".join(template)) / content["title"]
+
+    # the file `_version_` is not the same as the dataset `version` so we parse it out
+    # of the `dataset_id`
+    content["version"] = [content["dataset_id"].split("|")[0].split(".")[-1]]
+    if "directory_format_template_" in content:
+        return _form_from_template(content)
+
+    # otherwise we look for the project text in the url and return everything following
+    # it
+    urls = [url for url in content["url"] if "application/netcdf|HTTPServer"]
+    project = (
+        content["project"][0]
+        if isinstance(content["project"], list)
+        else content["project"]
+    )
+    if not urls:
+        raise ValueError(f"Could not find a http link in {content['url']}")
+    match = re.search(rf".*({project.lower()}.*.nc)|.*", urls[0])
+    if not match:
+        raise ValueError(f"Could not parse out the path from {urls[0]}")
+    return Path(match.group(1))

--- a/intake_esgf/base.py
+++ b/intake_esgf/base.py
@@ -42,7 +42,7 @@ def combine_results(dfs: list[pd.DataFrame]) -> pd.DataFrame:
     group_cols = [
         col for col in df.columns if col not in ["version", "data_node", "id"]
     ]
-    for _, grp in df.groupby(group_cols):
+    for _, grp in df.groupby(group_cols, dropna=False):
         df = df.drop(grp.iloc[1:].index)
         df.loc[grp.index[0], "id"] = grp.id.to_list()
     df = df.drop(columns="data_node")
@@ -348,7 +348,6 @@ def get_dataframe_columns(content: dict[str, Any]) -> list[str]:
     # CMIP5 is a disaster so...
     if "project" in content and content["project"] == "CMIP5":
         return [
-            "product",
             "institute",
             "model",
             "experiment",

--- a/intake_esgf/catalog.py
+++ b/intake_esgf/catalog.py
@@ -310,6 +310,9 @@ class ESGFCatalog:
                 return pd.DataFrame([])
             return df
 
+        if isinstance(tracking_ids, str):
+            tracking_ids = [tracking_ids]
+
         # log what is being searched for
         self.logger.info("\x1b[36;32mfrom_tracking_ids begin\033[0m")
 

--- a/intake_esgf/catalog.py
+++ b/intake_esgf/catalog.py
@@ -102,6 +102,7 @@ class ESGFCatalog:
         if self.esgf_data_root is not None:
             self.logger.info(f"ESGF dataroot set {self.esgf_data_root}")
         self.session_time = pd.Timestamp.now()
+        self.last_search = {}
 
     def __repr__(self):
         """Return the unique facets and values from the search."""
@@ -274,7 +275,7 @@ class ESGFCatalog:
 
         search_time = time.time() - search_time
         self.logger.info(f"\x1b[36;32msearch end\033[0m total_time={search_time:.2f}")
-
+        self.last_search = search
         return self
 
     def from_tracking_ids(
@@ -414,7 +415,7 @@ class ESGFCatalog:
         def _get_file_info(index, dataset_ids):
             try:
                 info = index.get_file_info(list(dataset_ids.keys()))
-            except ValueError:
+            except NoSearchResults:
                 return []
             except requests.exceptions.RequestException:
                 self.logger.info(f"└─{index} \x1b[91;20mno response\033[0m")

--- a/intake_esgf/core/globus.py
+++ b/intake_esgf/core/globus.py
@@ -127,9 +127,7 @@ class GlobusESGFIndex:
             self.logger.info(f"└─{self} results={len(infos)} {response_time=:.2f}")
         return infos
 
-    def from_tracking_ids(self, tracking_ids: Union[str, list[str]]) -> pd.DataFrame:
-        if isinstance(tracking_ids, str):
-            tracking_ids = [tracking_ids]
+    def from_tracking_ids(self, tracking_ids: list[str]) -> pd.DataFrame:
         response = SearchClient().post_search(
             self.index_id,
             SearchQuery("").add_filter("tracking_id", tracking_ids, type="match_any"),

--- a/intake_esgf/core/globus.py
+++ b/intake_esgf/core/globus.py
@@ -1,27 +1,16 @@
 """A Globus-based ESGF1 style index."""
 
 import time
-from pathlib import Path
 from typing import Any, Union
 
 import pandas as pd
 from globus_sdk import SearchClient, SearchQuery
 
-from intake_esgf.base import expand_cmip5_record, get_dataframe_columns
-
-
-def _form_path(content):
-    content["version"] = [content["dataset_id"].split("|")[0].split(".")[-1]]
-    file_path = content["directory_format_template_"][0]
-    return (
-        Path(
-            file_path.replace("%(root)s/", "")
-            .replace("%(", "{")
-            .replace(")s", "[0]}")
-            .format(**content)
-        )
-        / content["title"]
-    )
+from intake_esgf.base import (
+    expand_cmip5_record,
+    get_content_path,
+    get_dataframe_columns,
+)
 
 
 class GlobusESGFIndex:
@@ -127,11 +116,7 @@ class GlobusESGFIndex:
                         if "HTTPServer" in url
                     ],
                 }
-                # build the path from the template
-                content["version"] = [
-                    content["dataset_id"].split("|")[0].split(".")[-1]
-                ]
-                info["path"] = _form_path(content)
+                info["path"] = get_content_path(content)
                 infos.append(info)
         response_time = time.time() - response_time
         if self.logger is not None:

--- a/intake_esgf/core/globus.py
+++ b/intake_esgf/core/globus.py
@@ -7,7 +7,7 @@ from typing import Any, Union
 import pandas as pd
 from globus_sdk import SearchClient, SearchQuery
 
-from intake_esgf.base import get_dataframe_columns
+from intake_esgf.base import expand_cmip5_record, get_dataframe_columns
 
 
 def _form_path(content):
@@ -82,7 +82,16 @@ class GlobusESGFIndex:
                 }
                 record["project"] = content["project"][0]
                 record["id"] = g["subject"]
-                df.append(record)
+                if record["project"] == "CMIP5":
+                    variables = search["variable"] if "variable" in search else []
+                    if not isinstance(variables, list):
+                        variables = [variables]
+                    record = expand_cmip5_record(
+                        variables,
+                        content["variable"],
+                        record,
+                    )
+                df += record if isinstance(record, list) else [record]
         df = pd.DataFrame(df)
         response_time = time.time() - response_time
 

--- a/intake_esgf/core/globus.py
+++ b/intake_esgf/core/globus.py
@@ -72,7 +72,11 @@ class GlobusESGFIndex:
             for g in response["gmeta"]:
                 content = g["entries"][0]["content"]
                 record = {
-                    facet: content[facet][0]
+                    facet: (
+                        content[facet][0]
+                        if isinstance(content[facet], list)
+                        else content[facet]
+                    )
                     for facet in get_dataframe_columns(content)
                     if facet in content
                 }
@@ -136,7 +140,11 @@ class GlobusESGFIndex:
         for g in response["gmeta"]:
             content = g["entries"][0]["content"]
             record = {
-                facet: content[facet][0]
+                facet: (
+                    content[facet][0]
+                    if isinstance(content[facet], list)
+                    else content[facet]
+                )
                 for facet in get_dataframe_columns(content)
                 if facet in content
             }

--- a/intake_esgf/core/solr.py
+++ b/intake_esgf/core/solr.py
@@ -1,13 +1,16 @@
 """A ESGF1 Solr index class."""
 
 import time
-from pathlib import Path
 from typing import Any, Union
 
 import pandas as pd
 import requests
 
-from intake_esgf.base import expand_cmip5_record, get_dataframe_columns
+from intake_esgf.base import (
+    expand_cmip5_record,
+    get_content_path,
+    get_dataframe_columns,
+)
 from intake_esgf.exceptions import NoSearchResults
 
 
@@ -113,17 +116,7 @@ class SolrESGFIndex:
             info["checksum_type"] = doc["checksum_type"][0]
             info["checksum"] = doc["checksum"][0]
             info["size"] = doc["size"]
-            doc["version"] = [doc["dataset_id"].split("|")[0].split(".")[-1]]
-            file_path = doc["directory_format_template_"][0]
-            info["path"] = (
-                Path(
-                    file_path.replace("%(root)s/", "")
-                    .replace("%(", "{")
-                    .replace(")s", "[0]}")
-                    .format(**doc)
-                )
-                / doc["title"]
-            )
+            info["path"] = get_content_path(doc)
             for entry in doc["url"]:
                 link, _, link_type = entry.split("|")
                 if link_type not in info:

--- a/intake_esgf/core/solr.py
+++ b/intake_esgf/core/solr.py
@@ -91,7 +91,7 @@ class SolrESGFIndex:
             distrib=self.distrib,
             dataset_id=dataset_ids,
         )
-        response = esg_search(self.url, params=search)["response"]
+        response = esg_search(self.url, **search)["response"]
         if not response["numFound"]:
             if self.logger is not None:
                 self.logger.info(f"└─{self} no results")

--- a/intake_esgf/core/solr.py
+++ b/intake_esgf/core/solr.py
@@ -67,11 +67,11 @@ class SolrESGFIndex:
             self.logger.info(f"└─{self} results={len(df)} {total_time=:.2f}")
         return df
 
-    def from_tracking_ids(self, tracking_ids: Union[str, list[str]]) -> pd.DataFrame:
+    def from_tracking_ids(self, tracking_ids: list[str]) -> pd.DataFrame:
         total_time = time.time()
-        if isinstance(tracking_ids, str):
-            tracking_ids = [tracking_ids]
-        response = esg_search(self.url, tracking_id=tracking_ids)["response"]
+        response = esg_search(self.url, type="File", tracking_id=tracking_ids)[
+            "response"
+        ]
         if not response["numFound"]:
             if self.logger is not None:
                 self.logger.info(f"└─{self} no results")
@@ -96,7 +96,6 @@ class SolrESGFIndex:
         total_time = time.time()
         search = dict(
             type="File",
-            format="application/solr+json",
             limit=1000,  # FIX: need to manually paginate
             latest=True,
             retracted=False,

--- a/intake_esgf/core/solr.py
+++ b/intake_esgf/core/solr.py
@@ -42,7 +42,7 @@ class SolrESGFIndex:
         df = []
         for doc in response["docs"]:
             record = {
-                facet: doc[facet][0]
+                facet: doc[facet][0] if isinstance(doc[facet], list) else doc[facet]
                 for facet in get_dataframe_columns(doc)
                 if facet in doc
             }
@@ -67,7 +67,7 @@ class SolrESGFIndex:
         df = []
         for doc in response["docs"]:
             record = {
-                facet: doc[facet][0]
+                facet: doc[facet][0] if isinstance(doc[facet], list) else doc[facet]
                 for facet in get_dataframe_columns(doc)
                 if facet in doc
             }

--- a/intake_esgf/core/solr.py
+++ b/intake_esgf/core/solr.py
@@ -92,7 +92,7 @@ class SolrESGFIndex:
             self.logger.info(f"└─{self} results={len(df)} {total_time=:.2f}")
         return df
 
-    def get_file_info(self, dataset_ids: list[str]) -> dict[str, Any]:
+    def get_file_info(self, dataset_ids: list[str], **facets) -> dict[str, Any]:
         total_time = time.time()
         search = dict(
             type="File",
@@ -103,6 +103,7 @@ class SolrESGFIndex:
             distrib=self.distrib,
             dataset_id=dataset_ids,
         )
+        search.update(facets)
         response = esg_search(self.url, **search)["response"]
         if not response["numFound"]:
             if self.logger is not None:

--- a/intake_esgf/core/solr.py
+++ b/intake_esgf/core/solr.py
@@ -7,7 +7,7 @@ from typing import Any, Union
 import pandas as pd
 import requests
 
-from intake_esgf.base import get_dataframe_columns
+from intake_esgf.base import expand_cmip5_record, get_dataframe_columns
 from intake_esgf.exceptions import NoSearchResults
 
 
@@ -48,7 +48,16 @@ class SolrESGFIndex:
             }
             record["project"] = doc["project"][0]
             record["id"] = doc["id"]
-            df.append(record)
+            if record["project"] == "CMIP5":
+                variables = search["variable"] if "variable" in search else []
+                if not isinstance(variables, list):
+                    variables = [variables]
+                record = expand_cmip5_record(
+                    variables,
+                    doc["variable"],
+                    record,
+                )
+            df += record if isinstance(record, list) else [record]
         df = pd.DataFrame(df)
         total_time = time.time() - total_time
         if self.logger is not None:

--- a/intake_esgf/tests/test_basic.py
+++ b/intake_esgf/tests/test_basic.py
@@ -1,11 +1,13 @@
 from intake_esgf import ESGFCatalog
 from intake_esgf.exceptions import NoSearchResults
 
+SOLR_TEST = "esgf-node.ornl.gov"
+
 
 def test_search():
-    cat = ESGFCatalog(esgf1_indices="esgf-node.llnl.gov")
+    cat = ESGFCatalog(esgf1_indices=SOLR_TEST)
     print(cat)
-    cat = ESGFCatalog(esgf1_indices=["esgf-node.llnl.gov"]).search(
+    cat = ESGFCatalog(esgf1_indices=[SOLR_TEST]).search(
         experiment_id="historical",
         source_id="CanESM5",
         variable_id=["gpp"],
@@ -42,7 +44,7 @@ def test_noresults():
 
 
 def test_tracking_ids():
-    cat = ESGFCatalog().from_tracking_ids(
+    cat = ESGFCatalog(esgf1_indices=SOLR_TEST).from_tracking_ids(
         "hdl:21.14100/0577d84f-9954-494f-8cc8-465aa4fd910e"
     )
     assert len(cat.df) == 1

--- a/intake_esgf/tests/test_globus.py
+++ b/intake_esgf/tests/test_globus.py
@@ -1,0 +1,63 @@
+from intake_esgf.core import GlobusESGFIndex
+from intake_esgf.exceptions import NoSearchResults
+
+index = GlobusESGFIndex("ornl-dev")
+cmip6 = dict(
+    experiment_id="historical",
+    source_id="CanESM5",
+    variable_id="tas",
+    variant_label="r1i1p1f1",
+    frequency="mon",
+)
+# we test a cmip5 search because there are specialized code branches
+cmip5 = dict(
+    project="CMIP5",
+    experiment="historical",
+    model="CanESM2",
+    variable="tas",
+    ensemble="r1i1p1",
+    time_frequency="mon",
+)
+
+
+def test_search():
+    df = index.search(**cmip5)
+    assert len(df) > 0
+    df = index.search(**cmip6)
+    assert len(df) > 0
+
+
+def test_tracking_ids():
+    df = index.from_tracking_ids(["hdl:21.14100/872062df-acae-499b-aa0f-9eaca7681abc"])
+    assert len(df) > 0
+
+
+def test_get_file_info():
+    dataset_id = "CMIP6.CMIP.CCCma.CanESM5.historical.r1i1p1f1.Amon.tas.gn.v20190429|esgf-node.ornl.gov"
+    infos = index.get_file_info([dataset_id])
+    assert isinstance(infos, list)
+    assert len(infos) == 1
+    assert isinstance(infos[0], dict)
+    assert infos[0]["dataset_id"] == dataset_id
+
+
+def test_null():
+    try:
+        index.search(variable_id="does_not_exist")
+    except NoSearchResults:
+        pass
+    try:
+        index.from_tracking_ids(["does_not_exist"])
+    except NoSearchResults:
+        pass
+    try:
+        index.get_file_info(["does_not_exist"])
+    except NoSearchResults:
+        pass
+
+
+# because anl encodes booleans as strings
+def test_anl():
+    index = GlobusESGFIndex("anl-dev")
+    df = index.search(latest=True, **cmip6)
+    assert len(df) > 0

--- a/intake_esgf/tests/test_projects.py
+++ b/intake_esgf/tests/test_projects.py
@@ -1,0 +1,23 @@
+from intake_esgf import ESGFCatalog
+
+
+def test_cmip5():
+    cat = ESGFCatalog().search(
+        project="CMIP5",
+        experiment="historical",
+        cmor_table="Amon",
+        variable="tas",
+    )
+    cat.remove_ensembles()
+    assert len(cat.model_groups()) == 44
+
+
+def test_cmip3():
+    cat = ESGFCatalog().search(
+        project="CMIP3",
+        experiment="historical",
+        time_frequency="mon",
+        variable="tas",
+    )
+    cat.remove_ensembles()
+    assert len(cat.model_groups()) == 24

--- a/intake_esgf/tests/test_solr.py
+++ b/intake_esgf/tests/test_solr.py
@@ -1,0 +1,56 @@
+from intake_esgf.core import SolrESGFIndex
+from intake_esgf.exceptions import NoSearchResults
+
+index = SolrESGFIndex("esgf-node.llnl.gov", distrib=False)
+cmip6 = dict(
+    experiment_id="historical",
+    source_id="CanESM5",
+    variable_id="tas",
+    variant_label="r1i1p1f1",
+    frequency="mon",
+)
+# we test a cmip5 search because there are specialized code branches
+cmip5 = dict(
+    project="CMIP5",
+    experiment="historical",
+    model="CanESM2",
+    variable="tas",
+    ensemble="r1i1p1",
+    time_frequency="mon",
+)
+
+
+def test_search():
+    df = index.search(**cmip5)
+    assert len(df) > 0
+    df = index.search(**cmip6)
+    assert len(df) > 0
+
+
+def test_tracking_ids():
+    df = index.from_tracking_ids(["hdl:21.14100/872062df-acae-499b-aa0f-9eaca7681abc"])
+    assert len(df) > 0
+
+
+def test_get_file_info():
+    dataset_id = "CMIP6.CMIP.CCCma.CanESM5.historical.r1i1p1f1.Amon.tas.gn.v20190429|aims3.llnl.gov"
+    infos = index.get_file_info([dataset_id])
+    assert isinstance(infos, list)
+    assert len(infos) == 1
+    assert isinstance(infos[0], dict)
+    assert infos[0]["dataset_id"] == dataset_id
+
+
+def test_null():
+    try:
+        index.search(variable_id="does_not_exist")
+    except NoSearchResults:
+        pass
+    try:
+        index.from_tracking_ids(["does_not_exist"])
+    except NoSearchResults:
+        pass
+    try:
+        index.get_file_info(["does_not_exist"])
+    except NoSearchResults:
+        pass


### PR DESCRIPTION
- the columns of the underlying pandas dataframe are now generated from the `dataset_id_template_` field in the response (CMIP5 records are inconsistently ingested, so their columns are hard coded).
- a function now will return facets by 'type' (variable, variant, and grid) allowing functions like `model_groups()` to work by abstracting these notions.
- CMIP5 file info will only return for the variables requested, a great convenience as they ingested records where dataset_ids map to full tables of variables.
- tested against CMIP3 and CMIP5, other projects to follow.