### PR TITLE
ADD: Globus transfer

### DIFF
--- a/doc/globus.md
+++ b/doc/globus.md
@@ -1,0 +1,79 @@
+---
+jupytext:
+  text_representation:
+    format_name: myst
+kernelspec:
+  display_name: Python 3
+  name: python3
+---
+
+# Globus Transfers
+
+```{warning}
+This page describes a feature that we are currently testing. The interface is not yet well defined and may change. Some cells will not render as they depend on user authentication and personal information. If you have input on how to improve this interface, please reach [out](https://github.com/esgf2-us/intake-esgf/issues).
+```
+
+## Setting Up
+
+Chances are if you are reading this, you are already familiar with [Globus](https://www.globus.org/). In case that you are not, ​Globus is research cyberinfrastructure, developed so you can easily, reliably and securely move, share, & discover data no matter where it lives – from a supercomputer, lab cluster, tape archive, public cloud or laptop.
+
+A portion of the ESGF data archive is stored in public [Guest Collections](https://docs.globus.org/globus-connect-server/v5/reference/collection/) and access information included in some ESGF index nodes. This means that a portion of the ESGF archive can be accessed using Globus Transfer. These transfers can be triggered seamlessly in `intake-esgf` if you satisfy a few requirements. You will need:
+
+1. A Globus login. In order to manage permissions, Globus requires an identity. Simply try to login at [https://www.globus.org/](https://www.globus.org/) and first look through the list of supported institutions to login with your credentials. If your institution is not listed, you may login with another option list below the institution pulldown.
+2. A place to send data. Globus transfer uses custom software to both send and receive data. In their parlance, you need write access to another *collection* which represents where you will send the data. It is possible to download to your personal computer. You will need to download [Globus Connect Personal](https://app.globus.org/collections/gcp) and have it running and connected when you initiate the transfer.
+3. The `UUID` of the destination collection. The `UUID` can be found by navigating to the [collection](https://app.globus.org/file-manager/collections) in Globus, clicking the `⋮` to show the collection properties, and copying the `UUID` value listed.
+
+## Initiating the Transfer
+
+In this case we will use the [configuration](configure) options to only query the `anl-dev` globus-based index. This is just to keep the example script simple. There is Globus transfer information in several of the indices. For demonstration, we will search for a few files for a model whose file sizes are smaller.
+
+```{code-cell}
+:tags: [remove-cell]
+import intake_esgf
+from intake_esgf import ESGFCatalog
+```
+
+```{code-cell}
+with intake_esgf.conf.set(indices={"ornl-dev": False}):
+    cat = ESGFCatalog()
+    cat.search(
+        experiment_id="historical",
+        source_id="CanESM5",
+        frequency="mon",
+        variable_id=[
+            "pr",
+            "tas",
+            "gpp",
+        ],
+        member_id="r1i1p1f1",
+    )
+```
+
+This portion of the process what you would do normally. To use globus transfers where possible, you need to include additional arguments to `to_dataset_dict()`. The first is `globus_endpoint`, the `UUID` of the destination collection to which you will transfer the data. The second is `globus_path`, any additional path you wish to add to the root path of the destination collection.
+
+```{code-cell}
+:tags: [skip-execution]
+dsd = cat.to_dataset_dict(
+    globus_endpoint=COLLECTION_UUID, # <-- your data here
+    globus_path="data/ESGF-Data", # <-- additional path
+)
+```
+
+Internally this will do several things:
+
+1. We use the datasets present in your catalog to query the indices again for file information. This information is partitioned into that which has an associated Globus collection and that for which we will need to use https to download. The information that has a Globus collection is further partitioned preferring the collection with the fastest transfer times for you.
+2. We remove the file information which we detect is already present in the local cache.
+3. We submit the Globus transfer(s) and log the `task_id` to the `intake-esgf` [logfile](logging). You will not see anything on the screen to indicate that the transfer is ongoing, but can monitor the progress by going to your [activity](https://app.globus.org/activity) on globus.org.
+4. Once the the Globus transfer(s) are underway, we will download the remaining files using https.
+5. After the https downloads have completed, we block further progress until the Globus transfers report that they have succeeded.
+
+Then the code progresses as usual, looking for cell measures and loading files into xarray Datasets.
+
+## What Can Go Wrong?
+
+While this interface maintains the `intake-esgf` paradigm, and also makes using Globus transfers very simple, it also poses a few difficulties.
+
+1. Your `local_cache` may not include the location to where you transfered data. Technically you can use this approach to transfer data to any collection, not necesarily to the resource on which you are working.
+2. Furthermore, even if you execute this script on the resource which corresponds to the `globus_endpoint` you provided to `to_dataset_dict()`, the local cache directory may not point to where Globus transferred data. So if the `collection_root = /home/username/` and you set your local cache to `/home/username/data/ESGF-Data`, then you should have given `to_dataset_dict()` the option `globus_path="data/ESGF-Data"`. However, the collection root is not something we can always query and thus have no way to verify.
+
+Please [tell](https://github.com/esgf2-us/intake-esgf/issues) us what you think of this interface.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -60,6 +60,13 @@ or through ``conda-forge``
 .. toctree::
    :maxdepth: 2
    :hidden:
+   :caption: Experimental
+
+   globus
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
    :caption: Communicate
 
    GitHub repository <https://github.com/esgf2-us/intake-esgf>

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -44,7 +44,7 @@ print(cat)  # <-- nothing to see here yet
 
 To populate the catalog, perform a search using the traditional facets. If you
 are not familiar with these, we recommend you starting with
-our[beginner](beginner) tutorial.
+our [beginner](beginner) tutorial.
 
 ```{code-cell}
 cat.search(

--- a/intake_esgf/catalog.py
+++ b/intake_esgf/catalog.py
@@ -343,79 +343,10 @@ class ESGFCatalog:
 
         return self
 
-    def to_dataset_dict(
-        self,
-        minimal_keys: bool = True,
-        ignore_facets: Union[None, str, list[str]] = None,
-        separator: str = ".",
-        num_threads: int = 6,
-        quiet: bool = False,
-        add_measures: bool = True,
-        operators: list[Any] = [],
-    ) -> dict[str, xr.Dataset]:
-        """Return the current search as a dictionary of datasets.
-
-        By default, the keys of the returned dictionary are the minimal set of facets
-        required to uniquely describe the search. If you prefer to use a full set of
-        facets, set `minimal_keys=False`.
-
-        Parameters
-        ----------
-        minimal_keys
-            Disable to return a dictonary whose keys are formed using all facets, by
-            default we use a minimal set of facets to build the simplest keys.
-        ignore_facets
-            When constructing the dictionary keys, which facets should we ignore?
-        separator
-            When generating the keys, the string to use as a seperator of facets.
-        num_threads
-            The number of threads to use when downloading files.
-        """
-        if self.df is None or len(self.df) == 0:
-            raise ValueError("No entries to retrieve.")
-        logger = intake_esgf.conf.get_logger()
-        # The keys of the returned dictionary should only consist of the facets that are
-        # different.
-        output_key_format = []
-        if ignore_facets is None:
-            ignore_facets = []
-        if isinstance(ignore_facets, str):
-            ignore_facets = [ignore_facets]
-        # ...but these we always ignore
-        ignore_facets += [
-            "version",
-            "id",
-        ]
-        for col in self.df.drop(columns=ignore_facets):
-            if minimal_keys:
-                if not (self.df[col].iloc[0] == self.df[col]).all():
-                    output_key_format.append(col)
-            else:
-                output_key_format.append(col)
-        if not output_key_format:  # at minimum we have the variable id as a key
-            output_key_format = [get_facet_by_type(self.df, "variable")]
-
-        # Populate a dictionary of dataset_ids in this search and which keys they will
-        # map to in the output dictionary. This is complicated by CMIP5 where the
-        # dataset_id -> variable mapping is not unique.
-        dataset_ids = {}
-        for _, row in self.df.iterrows():
-            key = separator.join([row[k] for k in output_key_format])
-            for dataset_id in row["id"]:
-                if dataset_id in dataset_ids:
-                    if isinstance(dataset_ids[dataset_id], str):
-                        dataset_ids[dataset_id] = [dataset_ids[dataset_id]]
-                    dataset_ids[dataset_id].append(key)
-                else:
-                    dataset_ids[dataset_id] = key
-
-        # Some projects use dataset_ids to refer to collections of variables. So we need
-        # to pass the variables to the file info search to make sure we do not get more
-        # than we want.
-        search_facets = {}
-        variable_facet = get_facet_by_type(self.df, "variable")
-        if variable_facet in self.last_search:
-            search_facets[variable_facet] = self.last_search[variable_facet]
+    def _get_file_info(
+        self, dataset_ids, quiet, separator, search_facets
+    ) -> list[dict]:
+        """Query and return file information for the given datasets."""
 
         def _get_file_info(index, dataset_ids, **search_facets):
             try:
@@ -430,6 +361,7 @@ class ESGFCatalog:
                 return []
             return info
 
+        logger = intake_esgf.conf.get_logger()
         logger.info("\x1b[36;32mfile info begin\033[0m")
 
         # threaded file info over indices and flatten output
@@ -485,6 +417,13 @@ class ESGFCatalog:
         infos = [info for _, info in merged_info.items()]
         info_time = time.time() - info_time
         logger.info(f"\x1b[36;32mfile info end\033[0m total_time={info_time:.2f}")
+        return infos
+
+    def _move_data(self, infos, num_threads):
+        """Move data either by https or globus transfers."""
+        logger = intake_esgf.conf.get_logger()
+        logger.info("\x1b[36;32mmove data begin\033[0m")
+        move_time = time.time()
 
         # Download in parallel using threads
         fetch = partial(
@@ -494,6 +433,92 @@ class ESGFCatalog:
             esg_dataroot=self.esg_dataroot,
         )
         results = ThreadPool(min(num_threads, len(infos))).imap_unordered(fetch, infos)
+
+        move_time = time.time() - move_time
+        logger.info(f"\x1b[36;32mmove data end\033[0m total_time={move_time:.2f}")
+        return results
+
+    def to_dataset_dict(
+        self,
+        minimal_keys: bool = True,
+        ignore_facets: Union[None, str, list[str]] = None,
+        separator: str = ".",
+        num_threads: int = 6,
+        quiet: bool = False,
+        add_measures: bool = True,
+        operators: list[Any] = [],
+    ) -> dict[str, xr.Dataset]:
+        """Return the current search as a dictionary of datasets.
+
+        By default, the keys of the returned dictionary are the minimal set of facets
+        required to uniquely describe the search. If you prefer to use a full set of
+        facets, set `minimal_keys=False`.
+
+        Parameters
+        ----------
+        minimal_keys
+            Disable to return a dictonary whose keys are formed using all facets, by
+            default we use a minimal set of facets to build the simplest keys.
+        ignore_facets
+            When constructing the dictionary keys, which facets should we ignore?
+        separator
+            When generating the keys, the string to use as a seperator of facets.
+        num_threads
+            The number of threads to use when downloading files.
+        """
+        if self.df is None or len(self.df) == 0:
+            raise ValueError("No entries to retrieve.")
+
+        # The keys of the returned dictionary should only consist of the facets that are
+        # different.
+        output_key_format = []
+        if ignore_facets is None:
+            ignore_facets = []
+        if isinstance(ignore_facets, str):
+            ignore_facets = [ignore_facets]
+        # ...but these we always ignore
+        ignore_facets += [
+            "version",
+            "id",
+        ]
+        for col in self.df.drop(columns=ignore_facets):
+            if minimal_keys:
+                if not (self.df[col].iloc[0] == self.df[col]).all():
+                    output_key_format.append(col)
+            else:
+                output_key_format.append(col)
+        if not output_key_format:  # at minimum we have the variable id as a key
+            output_key_format = [get_facet_by_type(self.df, "variable")]
+
+        # Populate a dictionary of dataset_ids in this search and which keys they will
+        # map to in the output dictionary. This is complicated by CMIP5 where the
+        # dataset_id -> variable mapping is not unique.
+        dataset_ids = {}
+        for _, row in self.df.iterrows():
+            key = separator.join([row[k] for k in output_key_format])
+            for dataset_id in row["id"]:
+                if dataset_id in dataset_ids:
+                    if isinstance(dataset_ids[dataset_id], str):
+                        dataset_ids[dataset_id] = [dataset_ids[dataset_id]]
+                    dataset_ids[dataset_id].append(key)
+                else:
+                    dataset_ids[dataset_id] = key
+
+        # Some projects use dataset_ids to refer to collections of variables. So we need
+        # to pass the variables to the file info search to make sure we do not get more
+        # than we want.
+        search_facets = {}
+        variable_facet = get_facet_by_type(self.df, "variable")
+        if variable_facet in self.last_search:
+            search_facets[variable_facet] = self.last_search[variable_facet]
+
+        # Get the file info
+        infos = self._get_file_info(dataset_ids, quiet, separator, search_facets)
+
+        # Move the data if we need to
+        results = self._move_data(infos, num_threads)
+
+        # Load into xarray objects
         ds = {}
         for key, local_file in results:
             if local_file is None:  # there was a problem getting this file

--- a/intake_esgf/config.py
+++ b/intake_esgf/config.py
@@ -44,6 +44,7 @@ class Config(dict):
             if filename is not None
             else Path.home() / ".config/intake-esgf/conf.yaml"
         )
+        self.filename.parent.mkdir(parents=True, exist_ok=True)
         self.reload_all()
         self.temp = None
         super().__init__(**kwargs)

--- a/intake_esgf/core/globus.py
+++ b/intake_esgf/core/globus.py
@@ -1,7 +1,7 @@
 """A Globus-based ESGF1 style index."""
 
-import datetime
 import time
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Union
 

--- a/intake_esgf/core/globus.py
+++ b/intake_esgf/core/globus.py
@@ -119,6 +119,9 @@ class GlobusESGFIndex:
                         for url in content["url"]
                         if "HTTPServer" in url
                     ],
+                    "Globus": [
+                        url.split("|")[0] for url in content["url"] if "Globus" in url
+                    ],
                 }
                 info["path"] = get_content_path(content)
                 infos.append(info)

--- a/intake_esgf/core/globus.py
+++ b/intake_esgf/core/globus.py
@@ -1,16 +1,27 @@
 """A Globus-based ESGF1 style index."""
 
+import datetime
 import time
+from pathlib import Path
 from typing import Any, Union
 
 import pandas as pd
-from globus_sdk import SearchClient, SearchQuery
+from globus_sdk import (
+    NativeAppAuthClient,
+    RefreshTokenAuthorizer,
+    SearchClient,
+    SearchQuery,
+    TransferClient,
+)
+from globus_sdk.tokenstorage import SimpleJSONFileAdapter
 
 from intake_esgf.base import (
     expand_cmip5_record,
     get_content_path,
     get_dataframe_columns,
 )
+
+CLIENT_ID = "81a13009-8326-456e-a487-2d1557d8eb11"  # intake-esgf
 
 
 class GlobusESGFIndex:
@@ -198,3 +209,40 @@ def variable_info(query: str, project: str = "CMIP6") -> pd.DataFrame:
             df.append({key: content[key][0] for key in set(columns)})
     df = pd.DataFrame(df).sort_values(var_facet).set_index(var_facet)
     return df
+
+
+def get_authorized_transfer_client() -> TransferClient:
+    """Return a transfer client authorized to make transfers."""
+    config_path = Path.home() / ".config" / "intake-esgf"
+    token_adapter = SimpleJSONFileAdapter(config_path / "tokens.json")
+    client = NativeAppAuthClient(CLIENT_ID)
+    tokens = None
+    if token_adapter.file_exists():
+        tokens = token_adapter.get_token_data("transfer.api.globus.org")
+    if (
+        tokens is None
+        or datetime.fromtimestamp(tokens["expires_at_seconds"]) < datetime.now()
+    ):
+        client.oauth2_start_flow()
+        authorize_url = client.oauth2_get_authorize_url()
+        print(
+            f"""
+All interactions with Globus must be authorized. To ensure that we have permission to faciliate your transfer, please open the following link in your browser.
+
+{authorize_url}
+
+You will have to login (or be logged in) to your Globus account. Globus will also request that you give a label for this authorization. You may pick anything of your choosing. After following the instructions in your browser, Globus will generate a code which you must copy and paste here and then hit <enter>.\n"""
+        )
+        auth_code = input("> ").strip()
+        token_response = client.oauth2_exchange_code_for_tokens(auth_code)
+        token_adapter.store(token_response)
+        tokens = token_response.by_resource_server["transfer.api.globus.org"]
+    authorizer = RefreshTokenAuthorizer(
+        tokens["refresh_token"],
+        client,
+        access_token=tokens["access_token"],
+        expires_at=tokens["expires_at_seconds"],
+        on_refresh=token_adapter.on_refresh,
+    )
+    transfer_client = TransferClient(authorizer=authorizer)
+    return transfer_client

--- a/intake_esgf/database.py
+++ b/intake_esgf/database.py
@@ -1,4 +1,5 @@
 """Database functions which interact with SQLite."""
+
 import sqlite3
 from pathlib import Path
 from typing import Literal
@@ -102,3 +103,26 @@ def sort_download_links(link: str, df_rate: pd.DataFrame) -> float:
     if host not in df_rate.index:
         return df_rate["rate"].max() + np.random.rand(1)[0]
     return df_rate.loc[host, "rate"]
+
+
+def sort_globus_endpoints(uuid: str, df_rate: pd.DataFrame) -> float:
+    """Return the average download rate for the given endpoint uuid.
+
+    This function is to be used to sort the list of endpoints in terms of what is fastest
+    for the user. If a endpoint is not part of the dataframe, we return a random number
+    larger than the fastest server. This is so that future downloads from this host will
+    have entries in the database.
+
+    Parameters
+    ----------
+    uuid
+        The endpoint where the file(s) may be accessed download.
+    df_rate
+        The dataframe whose indices are hosts and contains a `rate` column.
+
+    """
+    if not len(df_rate):
+        return np.random.rand(1)[0]
+    if uuid not in df_rate.index:
+        return df_rate["rate"].max() + np.random.rand(1)[0]
+    return df_rate.loc[uuid, "rate"]


### PR DESCRIPTION
This patch enables data transfer via Globus. If you provide a destination endpoint, then a Globus transfer will just happen for all the files which are associated with an endpoint. 

```python
dsd = cat.to_dataset_dict(
    globus_endpoint=COLLECTION_UUID,
    globus_path="ESGF-Data",
)
```

Check the documentation for a new *Experimental* section which will explain how the interface works.