### PR TITLE
FIX: pass on the correct exception if not cell measures were found

### DIFF
--- a/intake_esgf/base.py
+++ b/intake_esgf/base.py
@@ -268,7 +268,7 @@ def add_cell_measures(ds: xr.Dataset, catalog) -> xr.Dataset:
     for add in to_add:
         try:
             ds = add_variable(add, ds, catalog)
-        except ValueError:
+        except NoSearchResults:
             pass
     return ds
 


### PR DESCRIPTION
We expect the measures to be found *somewhere* in the records, but I am finding that sometimes there are misspellings in the variable attributes. I found a CESM2 variable where `cell_measures: areacellg` which was causing a failure. We should just skip these as there is not much we can do.