### PR TITLE
FIX: latitude/longitude tolerance not large enough

### DIFF
--- a/intake_esgf/base.py
+++ b/intake_esgf/base.py
@@ -229,7 +229,7 @@ def add_variable(variable_id: str, ds: xr.Dataset, catalog) -> xr.Dataset:
     # many times the coordinates of the measures differ in only precision of the
     # variables and will lead to unexpected merged results
     var = cat.to_dataset_dict(quiet=True, add_measures=False)[variable_id]
-    var = var.reindex_like(ds, method="nearest", tolerance=1e-6)
+    var = var.reindex_like(ds, method="nearest", tolerance=1e-5)
     ds = xr.merge([ds, var[variable_id]])
     return ds
 


### PR DESCRIPTION
Sometimes cell measure information (such as `areacella` and `sftlf`) have their dimensions stored in single precision while the variables are in double. This is enough to make xarray's indexing treat these like they are different locations. When we associate cell measures with the datasets, we allow for a (relative) difference of `1e-6`. However, I am finding that this is not quite large enough for some CESM2 runs.