### PR TITLE
FIX: remove default `additional_df_cols`

### DIFF
--- a/intake_esgf/config.py
+++ b/intake_esgf/config.py
@@ -22,7 +22,7 @@ defaults = {
         "esgf.nci.org.au": False,
         "esgf-node.ornl.gov": False,
     },
-    "additional_df_cols": ["datetime_start", "datetime_stop"],
+    "additional_df_cols": [],
     "esg_dataroot": [
         "/p/css03/esgf_publish",
         "/eagle/projects/ESGF2/esg_dataroot",


### PR DESCRIPTION
I am getting reports such as #59 that including `datetime_{start|stop}` in the dataframe is causing crashes. There is nothing wrong with the implementation of the feature. It is rather caused by:

- not all records contain this metadata (they should, but this is the state of ESGF)
- if the metadata is not present, the dataframe entry is filled with a `NaN`
- the key generation routine for the output dataset dictionary uses columns in the dataframe in place of a fixed *master_id*
- thus we attempt to convert `NaN`'s to string for use as dictionary keys and get errors

This will get fixed in a rework of `to_dataset_dict()` that I have planned, where we will use the *master_id* as the key. For now I think the best thing is to turn off these columns by default. I have been instructing users to configure them off, but perhaps it makes more sense for those who need the feature to turn them on @huard.

```python
import intake_esgf
intake_esgf.conf.set(additional_df_cols=["datetime_start","datetime_stop"])
intake_esgf.conf.save()
```

Once you save the configuration, it will become the new default for your system. You will only need to do this once and we will read your default subsequently from the configure file.