### PR TITLE
FIX: globus transfers post `to_dataset_dict()` rework

### DIFF
--- a/intake_esgf/exceptions.py
+++ b/intake_esgf/exceptions.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+from globus_sdk import GlobusHTTPResponse
+
 
 class IntakeESGFException(Exception):
     """Exceptions from the intake-esgf package."""
@@ -51,3 +53,13 @@ class DatasetInitError(IntakeESGFException):
         return (
             f"xarray threw an exception while loading these keys: {self.problem_keys}"
         )
+
+
+class GlobusTransferError(IntakeESGFException):
+    """The globus task return a non-successful status."""
+
+    def __init__(self, task_doc: GlobusHTTPResponse):
+        self.task_doc = task_doc
+
+    def __str__(self):
+        return f"The Globus Transfer task is no longer active and was not successful: {self.task_doc}"

--- a/intake_esgf/tests/test_globus.py
+++ b/intake_esgf/tests/test_globus.py
@@ -1,3 +1,5 @@
+import pytest
+
 from intake_esgf.core import GlobusESGFIndex
 from intake_esgf.exceptions import NoSearchResults
 
@@ -61,3 +63,39 @@ def test_anl():
     index = GlobusESGFIndex("anl-dev")
     df = index.search(latest=True, **cmip6)
     assert len(df) > 0
+
+
+@pytest.mark.globus_auth
+def test_globus_transfer():
+    import os
+    from pathlib import Path
+
+    import intake_esgf
+    from intake_esgf import ESGFCatalog
+
+    # make sure this cache does not exist and set configuration
+    local_cache = Path().home() / "esgf-test"
+    os.system(f"rm -rf {local_cache}")
+    intake_esgf.conf.set(local_cache=[str(local_cache)], indices={"ornl-dev": False})
+
+    dsd = (
+        ESGFCatalog()
+        .search(
+            experiment_id="historical",
+            source_id="CanESM5",
+            frequency="mon",
+            variable_id=[
+                "pr",
+                "tas",
+                "gpp",
+            ],
+            member_id="r1i1p1f1",
+        )
+        .to_dataset_dict(
+            globus_endpoint="285fafe4-ae63-11ee-b085-4bb870e392e2",
+            globus_path="esgf-test",
+            add_measures=False,
+        )
+    )
+    os.system(f"rm -rf {local_cache}")
+    assert not (set(dsd) - set(["Amon.pr", "Amon.tas", "Lmon.gpp"]))


### PR DESCRIPTION
- globus paths were improperly harvested
- we created a special exception that will pass the task response from globus on error
- there is now a test marked `globus_auth` and will work only if I have authenticated and have my endpoint active