### PR TITLE
ADD: support for obs4MIPs and ProjectDownscale

### DIFF
--- a/intake_esgf/config.py
+++ b/intake_esgf/config.py
@@ -20,6 +20,7 @@ defaults = {
         "esgf-node.llnl.gov": False,
         "esgf.nci.org.au": False,
         "esgf-node.ornl.gov": False,
+        "esgf-fedtest.llnl.gov": False,
     },
     "additional_df_cols": [],
     "esg_dataroot": [

--- a/intake_esgf/exceptions.py
+++ b/intake_esgf/exceptions.py
@@ -63,3 +63,14 @@ class GlobusTransferError(IntakeESGFException):
 
     def __str__(self):
         return f"The Globus Transfer task is no longer active and was not successful: {self.task_doc}"
+
+
+class ProjectHasNoFacet(IntakeESGFException):
+    """You tried to use a project function which needs a facet that it does not have."""
+
+    def __init__(self, project: str, facet: str):
+        self.project = project
+        self.facet = facet
+
+    def __str__(self):
+        return f"The '{self.project}' project does not have a '{self.facet}' facet"

--- a/intake_esgf/projects.py
+++ b/intake_esgf/projects.py
@@ -292,11 +292,59 @@ class obs4MIPs(ESGFProject):
         return "grid_label"
 
 
+class ProjectDownscale(ESGFProject):
+    def __init__(self):
+        self.facets = [
+            "mip_era",
+            "activity_id",
+            "region_id",
+            "downscaling_source_id",
+            "institution_id",
+            "driving_source_id",
+            "driving_experiment_id",
+            "driving_variant_label",
+            "source_id",
+            "frequency",
+            "variable_id",
+            "version",
+            "data_node",
+        ]
+
+    def master_id_facets(self) -> list[str]:
+        return self.facets[:-2]
+
+    def id_facets(self) -> list[str]:
+        return self.facets
+
+    def relaxation_facets(self) -> list[str]:
+        # NOTE: This is used to find cell measures that are closely related to a given
+        # set of facets and in this project do not make sense.
+        return []
+
+    def variable_description_facets(self) -> list[str]:
+        # NOTE: This is used to find cell measures that are closely related to a given
+        # set of facets and in this project do not make sense.
+        return []
+
+    def variable_facet(self) -> str:
+        return "variable_id"
+
+    def model_facet(self) -> str:
+        return "source_id"
+
+    def variant_facet(self) -> str:
+        raise ProjectHasNoFacet("ProjectDownscale", "variant")
+
+    def grid_facet(self) -> str:
+        raise ProjectHasNoFacet("ProjectDownscale", "grid_label")
+
+
 projects = {
     "cmip6": CMIP6(),
     "cmip5": CMIP5(),
     "cmip3": CMIP3(),
     "obs4mips": obs4MIPs(),
+    "projectdownscale": ProjectDownscale(),
 }
 
 

--- a/intake_esgf/projects.py
+++ b/intake_esgf/projects.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 
-from intake_esgf.exceptions import ProjectNotSupported
+from intake_esgf.exceptions import ProjectHasNoFacet, ProjectNotSupported
 
 
 class ESGFProject(ABC):
@@ -250,7 +250,54 @@ class CMIP3(ESGFProject):
         return None
 
 
-projects = {"cmip6": CMIP6(), "cmip5": CMIP5(), "cmip3": CMIP3()}
+class obs4MIPs(ESGFProject):
+    def __init__(self):
+        self.facets = [
+            "activity_id",
+            "institution_id",
+            "source_id",
+            "frequency",
+            "variable_id",
+            "grid_label",
+            "version",
+            "data_node",
+        ]
+
+    def master_id_facets(self) -> list[str]:
+        return self.facets[:-2]
+
+    def id_facets(self) -> list[str]:
+        return self.facets
+
+    def relaxation_facets(self) -> list[str]:
+        # NOTE: This is used to find cell measures that are closely related to a given
+        # set of facets and in this project do not make sense.
+        return []
+
+    def variable_description_facets(self) -> list[str]:
+        # NOTE: This is used to find cell measures that are closely related to a given
+        # set of facets and in this project do not make sense.
+        return []
+
+    def variable_facet(self) -> str:
+        return "variable_id"
+
+    def model_facet(self) -> str:
+        return "source_id"
+
+    def variant_facet(self) -> str:
+        raise ProjectHasNoFacet("obs4mips", "variant")
+
+    def grid_facet(self) -> str:
+        return "grid_label"
+
+
+projects = {
+    "cmip6": CMIP6(),
+    "cmip5": CMIP5(),
+    "cmip3": CMIP3(),
+    "obs4mips": obs4MIPs(),
+}
 
 
 def get_project_facets(content: dict[str, str | list[str]]) -> list[str]:

--- a/intake_esgf/tests/test_projects.py
+++ b/intake_esgf/tests/test_projects.py
@@ -36,3 +36,18 @@ def test_obs4mips():
         except ProjectHasNoFacet:
             pass
         assert len(cat.df) == 1
+
+
+def test_projectdownscale():
+    # this project is only on a dev index for now
+    intake_esgf.conf.set(indices={"esgf-fedtest.llnl.gov": True})
+    cat = intake_esgf.ESGFCatalog().search(
+        project="ProjectDownscale",
+        downscaling_source_id="LOCA2",
+        driving_source_id="MRI-ESM2-0",
+    )
+    try:  # this shouldn't work but fail nicely
+        cat.model_groups()
+    except ProjectHasNoFacet:
+        pass
+    assert len(cat.df) == 1

--- a/intake_esgf/tests/test_projects.py
+++ b/intake_esgf/tests/test_projects.py
@@ -1,4 +1,6 @@
+import intake_esgf
 from intake_esgf import ESGFCatalog
+from intake_esgf.exceptions import ProjectHasNoFacet
 
 
 def test_cmip5():
@@ -21,3 +23,16 @@ def test_cmip3():
     )
     cat.remove_ensembles()
     assert len(cat.model_groups()) == 24
+
+
+def test_obs4mips():
+    # this project is only on LLNL for now
+    with intake_esgf.conf.set(indices={"esgf-node.llnl.gov": True}):
+        cat = ESGFCatalog().search(
+            project="obs4MIPs", institution_id="NASA-LaRC", variable_id="rlus"
+        )
+        try:  # this shouldn't work but fail nicely
+            cat.model_groups()
+        except ProjectHasNoFacet:
+            pass
+        assert len(cat.df) == 1


### PR DESCRIPTION
The main different between this and what @lee1043 has is that I have added an exception type to throw when you attempt to use a facet type that a project does not have. For example, I have a function which produces model groups by grouping on facets representing the (model, variant, and grid). But these do not make sense for obs4MIPs and so now it will just fail (nicely) if you try to use `model_groups()` with that project.

For the facets to relax we need not error, we just return an empty list. This is currently only used in finding cell measures automatically which again does not apply for these projects and is even disabled for all projects other than CMIP6.

I also added a few tests just to make sure that if the indices are configured properly, we get the expected result.