### PR TITLE
FIX: `break_on_error=False` does not work properly

### DIFF
--- a/intake_esgf/catalog.py
+++ b/intake_esgf/catalog.py
@@ -632,7 +632,11 @@ class ESGFCatalog:
                 row["key"]: separator.join(row[key_format])
                 for _, row in self.df.iterrows()
             }
-            dsd = {key_new: dsd[key_old] for key_old, key_new in key_map.items()}
+            dsd = {
+                key_new: dsd[key_old]
+                for key_old, key_new in key_map.items()
+                if key_old in dsd
+            }
 
         return dsd
 


### PR DESCRIPTION
When setting `intake_esgf.conf.set(break_on_error=False)`, the code would correctly will raise a warning instead of an exception, but would fail when forming minimal keys. This is a simple fix to check that the old key is present in the output dictionary. Tests are added to check behavior.