### PR TITLE
FIX: `prefer_streaming=True` now returns all file links

### DIFF
--- a/intake_esgf/base.py
+++ b/intake_esgf/base.py
@@ -176,7 +176,7 @@ def partition_infos(
         # 2) does the user prefer to stream data?
         if prefer_streaming:
             # What possible links are there to stream from?
-            preferred_sources = ["OPENDAP"]  # move to configure
+            preferred_sources = ["VirtualZarr", "OPENDAP"]  # move to configure
             links = [
                 link
                 for src in (set(preferred_sources) & set(info))

--- a/intake_esgf/tests/test_basic.py
+++ b/intake_esgf/tests/test_basic.py
@@ -151,17 +151,18 @@ def test_partition_infos():
 
 
 def test_partition_infos_stream():
+    VALID_OPENDAP_LINK = "https://esgf-data1.llnl.gov/thredds/dodsC/css03_data/CMIP6/CMIP/AS-RCEC/TaiESM1/historical/r1i1p1f1/day/tasmax/gn/v20210517/tasmax_day_TaiESM1_historical_r1i1p1f1_gn_20100101-20141231.nc"
     infos = [
         {
             "key": "dataset1",
             "path": Path("file1"),
-            "VirtualZarr": ["link1", "link2"],
+            "VirtualZarr": [VALID_OPENDAP_LINK, VALID_OPENDAP_LINK],
         },
         {
             "key": "dataset2",
             "path": Path("file1"),
             "HTTPServer": ["link1", "link2"],
-            "OPENDAP": ["link1", "link2"],
+            "OPENDAP": [VALID_OPENDAP_LINK, VALID_OPENDAP_LINK],
         },
     ]
     infos_, ds = partition_infos(infos, False, False)


### PR DESCRIPTION
As brought to our attention by #90, `prefer_streaming=True` only returned the first OPENDAP link found in the file info, overwriting any values found in the returned dataset. This was just laziness on my part when I originally implemented this feature. This fix will, for each dataset:

- sort the OPENDAP links by the hosts which have provided the user the fastest download times
- append to a list of links for each dataset, the fastest link whose corresponding html page returns  a response
- if we fail to find a responding OPENDAP server, then this file will automatically get bumped into the list of things to download via https

h/t @Klemet