### PR TITLE
FIX: initialize file_start and file_end to None

### DIFF
--- a/intake_esgf/core/globus.py
+++ b/intake_esgf/core/globus.py
@@ -181,6 +181,7 @@ class GlobusESGFIndex:
                 }
                 info["path"] = base.get_content_path(content)
                 tstart, tend = base.get_time_extent(str(info["path"]))
+                info["file_start"] = info["file_end"] = None
                 if tstart is not None:
                     info["file_start"] = tstart
                     info["file_end"] = tend

--- a/intake_esgf/core/solr.py
+++ b/intake_esgf/core/solr.py
@@ -135,6 +135,7 @@ class SolrESGFIndex:
                     info[link_type].append(link)
                 infos.append(info)
                 tstart, tend = base.get_time_extent(str(info["path"]))
+                info["file_start"] = info["file_end"] = None
                 if tstart is not None:
                     info["file_start"] = tstart
                     info["file_end"] = tend


### PR DESCRIPTION
If you give a `file_start` and/or `file_end` for fixed frequency records, you will get an error. I am working too fast.