### PR TITLE
FIX: partition streaming logic and failing test

### DIFF
--- a/intake_esgf/base.py
+++ b/intake_esgf/base.py
@@ -108,7 +108,7 @@ def select_streaming_link(links: list[str], df_rate: pd.DataFrame) -> str:
     # This is particular to OPENDAP and will need rethought for other virtual
     # methods.
     for link in links:
-        resp = requests.get(link + ".html", stream=True, timeout=10)
+        resp = requests.head(link + ".html", timeout=10)
         if resp.status_code == 200:
             return link
     raise ValueError(f"None of these links appears functional {links}")

--- a/intake_esgf/base.py
+++ b/intake_esgf/base.py
@@ -172,7 +172,7 @@ def partition_infos(
             if key not in ds:
                 ds[key] = []
             ds[key].append(local_path)
-            infos_exist.append(info)  # maybe not needed
+            infos_exist.append(info)
             continue
         except FileNotFoundError:
             pass
@@ -191,13 +191,13 @@ def partition_infos(
                 # seen while downloading. If this fails, we revert to https.
                 try:
                     link = select_streaming_link(links, df_rate)
+                    if key not in ds:
+                        ds[key] = []
+                    ds[key].append(link)
+                    infos_stream.append(info)
+                    continue
                 except ValueError:
-                    break
-                if key not in ds:
-                    ds[key] = []
-                ds[key].append(link)
-                infos_stream.append(info)  # maybe not needed
-                continue
+                    pass
 
         # 3) does the user prefer to use globus transfer?
         if prefer_globus:

--- a/intake_esgf/tests/test_basic.py
+++ b/intake_esgf/tests/test_basic.py
@@ -169,10 +169,13 @@ def test_partition_infos_stream():
     assert max([len(infos_[p]) for p in ["exist", "stream", "globus"]]) == 0
     assert len(infos_["https"]) == 2
     assert len(ds) == 0
+    # The following is meant to test that if streaming is requested, you will
+    # get those links. However, the issue is that the code checks that the link
+    # is valid and many times OPENDAP fails.
     infos_, ds = partition_infos(infos, True, True)
-    assert max([len(infos_[p]) for p in ["exist", "globus", "https"]]) == 0
-    assert len(infos_["stream"]) == 2
-    assert len(ds) == 2
+    assert max([len(infos_[p]) for p in ["exist", "globus"]]) == 0
+    assert len(infos_["stream"] + infos_["https"]) == 2
+    assert len(ds) == len(infos_["stream"])
 
 
 @pytest.mark.globus_auth


### PR DESCRIPTION
This PR:

- moves to `requests.head` for checking link status which may be kinder to the server and lead to fewer failures
- corrects the `break` logic which was in fact skipping adding the failing OPENDAP link to https download
- adapts the test to conditionally check https links if OPENDAP links are failing