### PR TITLE
Set page size for searching solr indices to 1000 to avoid many small requests

### DIFF
--- a/intake_esgf/core/solr.py
+++ b/intake_esgf/core/solr.py
@@ -17,7 +17,7 @@ def esg_search(base_url, **search):
     if "format" not in search:
         search["format"] = "application/solr+json"
     offset = search.get("offset", 0)
-    limit = search.get("limit", 10)
+    limit = search.get("limit", 1000)
     total = offset + limit + 1
     while (offset + limit) < total:
         response = requests.get(f"{base_url}/esg-search/search", params=search)

--- a/intake_esgf/tests/test_basic.py
+++ b/intake_esgf/tests/test_basic.py
@@ -225,10 +225,10 @@ def test_nobreak():
             )
             .remove_ensembles()
         )
-        cat.df.loc[cat.df.index[0], "id"] = []  # fake there being no paths to download
+        cat.df.loc[cat.df.index[1], "id"] = []  # fake there being no paths to download
         with pytest.warns(
             UserWarning,
-            match="We could not download your entire catalog, missed={'CMIP6.CMIP.CCCma.CanESM5.historical.r1i1p1f1.Lmon.gpp.gn'}",
+            match="We could not download your entire catalog, missed={'CMIP6.CMIP.E3SM-Project.E3SM-1-1.historical.r1i1p1f1.Lmon.gpp.gr'}",
         ):
             paths = cat.to_path_dict()
         assert len(paths) == 1


### PR DESCRIPTION
Set the page size for searching solr indices to 1000 to avoid slow searches due to many small requests. I chose 1000 to align it with the globus number.