### PR TITLE
add NSF NCAR/GLADE CMIP mirror to default esg_dataroot search path

### DIFF
--- a/intake_esgf/config.py
+++ b/intake_esgf/config.py
@@ -32,6 +32,7 @@ defaults = {
         "/p/css03/esgf_publish",
         "/eagle/projects/ESGF2/esg_dataroot",
         "/global/cfs/projectdirs/m3522/cmip6/",
+        "/glade/campaign/collections/cmip.mirror",
     ],
     "local_cache": [
         "~/.esgf/",


### PR DESCRIPTION
This PR simply adds `/glade/campaign/collections/cmip.mirror` to the end of the `esg_dataroot` search path; this is the central repository for CMIP data available to all users at NSF NCAR.