### PR TITLE
ADD: Automatically detect slow/stalled downloads and cancel

### DIFF
--- a/intake_esgf/config.py
+++ b/intake_esgf/config.py
@@ -47,6 +47,7 @@ defaults = {
     "num_threads": 6,
     "break_on_error": True,
     "confirm_download": False,
+    "slow_download_threshold": 0.5,  # [Mb s-1]
 }
 
 
@@ -98,6 +99,7 @@ class Config(dict):
         num_threads: int | None = None,
         break_on_error: bool | None = None,
         confirm_download: bool | None = None,
+        slow_download_threshold: float | None = None,
     ):
         """Change intake-esgf configuration options.
 
@@ -138,6 +140,9 @@ class Config(dict):
             Should a user script continue if any of the datasets fail to load?
         confirm_download: bool
             Enable to require the user to confirm before downloads occur.
+        slow_download_threshold: float
+            The download rate in [Mb s-1] below which a download will be canceled in favor of
+            another link.
 
         Examples
         --------
@@ -199,6 +204,8 @@ class Config(dict):
             self["break_on_error"] = bool(break_on_error)
         if confirm_download is not None:
             self["confirm_download"] = bool(confirm_download)
+        if slow_download_threshold is not None:
+            self["slow_download_threshold"] = float(slow_download_threshold)
         return self._unset(temp)
 
     def __getitem__(self, item):

--- a/intake_esgf/exceptions.py
+++ b/intake_esgf/exceptions.py
@@ -13,6 +13,10 @@ class NoSearchResults(IntakeESGFException):
     """Search returned no results."""
 
 
+class StalledDownload(IntakeESGFException):
+    """Download speed has fallen below a set threshold."""
+
+
 class LocalCacheNotWritable(IntakeESGFException):
     """You do not have permission to write in the cache directories."""
 


### PR DESCRIPTION
Here is an initial take on how we can handled stalled/slow downloads.

In downloading a url, while we iterate over the response content, we now compute a mean transfer rate for the chunk and then a smoothed rate using [exponential smoothing](https://en.wikipedia.org/wiki/Exponential_smoothing). This will more heavily weight recent chunks' rates and help avoid noise in the system. Then we will cancel a download if:

1. The smoothed rate falls below a configurable value `intake_esgf.conf['slow_download_threshold']` by default set to `0.5 [Mb s-1]`.
2. The current transfer time needs to be beyond a safety period (2s) This gives some time for the smoothed rate to stabilize.
3. There must be more links available. This comes as a boolean `break_slow_downloads` that we can set if the url passed in is the last in the list. If we don't have anywhere else to look for the file, then there is no sense in canceling.

I have tested the smoothing outside of intake-esgf and it seems to work well, but I am currently thinking of how I can simulate a slow download and this test this logic.

Will close #130.
