### PR TITLE
FIX: Ignore time stamps if we do not know how to handle them

### DIFF
--- a/intake_esgf/base.py
+++ b/intake_esgf/base.py
@@ -622,8 +622,14 @@ def get_time_extent(
             s += "01"
         return pd.Timestamp(s)
 
+    # Try to parse out the filename
     match = re.search(r"_(\d+)-(\d+)", filename)
     if not match:
         return None, None
 
-    return _to_timestamp(match.group(1)), _to_timestamp(match.group(2))
+    # Try to convert to a pandas timestamp
+    try:
+        t0, tf = _to_timestamp(match.group(1)), _to_timestamp(match.group(2))
+    except Exception:
+        return None, None
+    return t0, tf


### PR DESCRIPTION
This is a bit of a punt but solves the current problem expressed in #137.  In particular this code runs:

```python
cat = intake_esgf.ESGFCatalog().search(
    activity_drs="HighResMIP",
    variable_id="tos",
    experiment_id=["control-1950"],
    source_id="HadGEM3-GC31-HH",
    frequency="day",
    file_start="20500101",
    file_end="20500301",
)
paths = cat.to_dataset_dict(minimal_keys=False)
```

despite HadGEM having an invalid `20050230` date in a filename. 

If we are unable to parse a date from the filename, then the start/end dates will just be None. At a later point, if we wanted to try to filter out as I did above with `file_start` and `file_end`, then files with None's in these slots are always included. Essentially we are just saying that if we cannot parse your date, then we cannot filter your file and that seems fair.