### PR TITLE
CHANGE: added a download mark and disable while servers are flaky

### DIFF
--- a/intake_esgf/tests/project/test_cmip3.py
+++ b/intake_esgf/tests/project/test_cmip3.py
@@ -1,3 +1,5 @@
+import pytest
+
 import intake_esgf
 from intake_esgf import ESGFCatalog
 
@@ -24,6 +26,7 @@ def test_cmip3_discovery():
     assert len(cat.model_groups()) == 1
 
 
+@pytest.mark.download
 def test_cmip3_download():
     """
     Test a small file download.

--- a/intake_esgf/tests/project/test_cmip5.py
+++ b/intake_esgf/tests/project/test_cmip5.py
@@ -1,3 +1,5 @@
+import pytest
+
 import intake_esgf
 from intake_esgf import ESGFCatalog
 
@@ -24,6 +26,7 @@ def test_cmip5_discovery():
     assert len(cat.model_groups()) == 2
 
 
+@pytest.mark.download
 def test_cmip5_download():
     """
     Test a small file download.

--- a/intake_esgf/tests/project/test_cmip6.py
+++ b/intake_esgf/tests/project/test_cmip6.py
@@ -1,3 +1,5 @@
+import pytest
+
 import intake_esgf
 from intake_esgf import ESGFCatalog
 
@@ -24,6 +26,7 @@ def test_cmip6_discovery():
     assert len(cat.model_groups()) == 1
 
 
+@pytest.mark.download
 def test_cmip6_download():
     """
     Test a small file download.
@@ -67,6 +70,7 @@ def test_cmip6_get_variable_info():
     assert df.iloc[0]["cf_standard_name"] == "stem_mass_content_of_carbon"
 
 
+@pytest.mark.download
 def test_cmip6_timestamps():
     """
     Test that timestamps effectively filter out files.
@@ -85,6 +89,7 @@ def test_cmip6_timestamps():
     assert len(paths) == 2
 
 
+@pytest.mark.download
 def test_cmip6_add_cell_measures():
     """
     Test that we can add cell measures even far away.

--- a/intake_esgf/tests/project/test_obs4MIPs.py
+++ b/intake_esgf/tests/project/test_obs4MIPs.py
@@ -27,6 +27,7 @@ def test_obs4MIPs_discovery():
         cat.remove_ensembles()
 
 
+@pytest.mark.download
 def test_obs4MIPs_download():
     """
     Test a small file download.

--- a/intake_esgf/tests/test_base.py
+++ b/intake_esgf/tests/test_base.py
@@ -292,6 +292,7 @@ def test_get_time_extent():
     assert t0 is None
 
 
+@pytest.mark.download
 def test_download_without_checksum(monkeypatch):
     """Test that downloading a file without a checksum works."""
     _get_file_info = ESGFCatalog._get_file_info

--- a/intake_esgf/tests/test_config.py
+++ b/intake_esgf/tests/test_config.py
@@ -85,6 +85,7 @@ def test_set_indices():
     assert num_on == 1
 
 
+@pytest.mark.download
 def test_confirm(monkeypatch):
     with intake_esgf.conf.set(confirm_download=True):
         cat = intake_esgf.ESGFCatalog().search(
@@ -103,6 +104,7 @@ def test_confirm(monkeypatch):
         assert len(ds) == 1
 
 
+@pytest.mark.download
 def test_break_on_error(monkeypatch):
     def fake_open_dataset(filename: Any):
         raise ValueError("Just needs to fail")
@@ -141,6 +143,7 @@ def test_additional_df_cols():
         assert all([col in cat.df.columns for col in extra])
 
 
+@pytest.mark.download
 def test_slow_cancel(tmp_path):
     intake_esgf.conf.set(slow_download_threshold=100)  # unreasonably fast speed
     with pytest.raises(StalledDownload):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,10 +68,11 @@ version_file_template = '__version__ = "{version}"'
 
 [tool.pytest.ini_options]
 console_output_style = "count"
-addopts = "--cov --cov-report=xml --verbose -m 'not (globus_auth or solr)'"
+addopts = "--cov --cov-report=xml --verbose -m 'not (globus_auth or solr or download)'"
 markers = [
     "globus_auth: tests which require globus authentication",
     "solr: tests which need to communicate to a Solr index",
+    "download: tests which need to download data",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
I have tried to expand test coverage while minimizing how much network activity we require, but I am still getting flaky tests because of connections. I have added a `download` mark and disabled these tests. Our coverage will fall temporarily, but we will get it back up.