### PR TITLE
CHANGE: Add an option to `to_dataset_dict` which passes kwargs to `open_mfdataset`

### DIFF
--- a/intake_esgf/catalog.py
+++ b/intake_esgf/catalog.py
@@ -777,24 +777,12 @@ class ESGFCatalog:
         ds: dict[str, xr.Dataset] = {}
         for key, files in paths.items():
             [self.logger.info(f"accessed {f}") for f in files]
-            if len(files) == 1:
-                try:
-                    ds[key] = xr.open_dataset(files[0])
-                except Exception as ex:
-                    warnings.warn(
-                        f"xarray threw an exception opening this file: {files[0]}"
-                    )
-                    failed_keys.append(key)
-                    exceptions.append(ex)
-            elif len(files) > 1:
-                try:
-                    ds[key] = xr.open_mfdataset(sorted(files))
-                except Exception as ex:
-                    warnings.warn(
-                        f"xarray threw an exception opening these files: {files}"
-                    )
-                    failed_keys.append(key)
-                    exceptions.append(ex)
+            try:
+                ds[key] = xr.open_mfdataset(sorted(files))
+            except Exception as ex:
+                warnings.warn(f"xarray threw an exception opening these files: {files}")
+                failed_keys.append(key)
+                exceptions.append(ex)
         if intake_esgf.conf["break_on_error"] and exceptions:
             for exc in exceptions:
                 print(exc)

--- a/intake_esgf/catalog.py
+++ b/intake_esgf/catalog.py
@@ -734,6 +734,7 @@ class ESGFCatalog:
         ignore_facets: None | str | list[str] = None,
         separator: str = ".",
         quiet: bool = False,
+        open_kwargs: dict[str, Any] | None = None,
     ) -> dict[str, xr.Dataset]:
         """
         Return the current search as a dictionary of datasets.
@@ -760,7 +761,14 @@ class ESGFCatalog:
             When generating the keys, the string to use as a seperator of facets.
         quiet: bool
             Enable to quiet the progress bars.
+        open_kwargs: dict
+            A dictionary of keyword arguments to pass through to xarray.open_mfdataset().
         """
+        # sanitize inputs
+        if open_kwargs is None:
+            open_kwargs = {}
+
+        # get the paths, passing along options
         paths = self.to_path_dict(
             prefer_streaming=prefer_streaming,
             globus_endpoint=globus_endpoint,
@@ -778,7 +786,7 @@ class ESGFCatalog:
         for key, files in paths.items():
             [self.logger.info(f"accessed {f}") for f in files]
             try:
-                ds[key] = xr.open_mfdataset(sorted(files))
+                ds[key] = xr.open_mfdataset(sorted(files), **open_kwargs)
             except Exception as ex:
                 warnings.warn(f"xarray threw an exception opening these files: {files}")
                 failed_keys.append(key)

--- a/intake_esgf/catalog.py
+++ b/intake_esgf/catalog.py
@@ -764,9 +764,9 @@ class ESGFCatalog:
         open_kwargs: dict
             A dictionary of keyword arguments to pass through to xarray.open_mfdataset().
         """
-        # sanitize inputs
+        # if no kwargs are passed, use the default dictionary
         if open_kwargs is None:
-            open_kwargs = {}
+            open_kwargs = intake_esgf.conf["default_open_kwargs"]
 
         # get the paths, passing along options
         paths = self.to_path_dict(

--- a/intake_esgf/config.py
+++ b/intake_esgf/config.py
@@ -3,6 +3,7 @@
 import contextlib
 import copy
 from pathlib import Path
+from typing import Any
 
 import yaml
 
@@ -49,6 +50,12 @@ defaults = {
     "confirm_download": False,
     "slow_download_threshold": 0.5,  # [Mb s-1]
     "print_log_on_error": False,
+    "default_open_kwargs": dict(
+        data_vars="minimal",
+        coords="minimal",
+        compat="override",
+        chunks="auto",
+    ),
 }
 
 
@@ -102,6 +109,7 @@ class Config(dict):
         confirm_download: bool | None = None,
         slow_download_threshold: float | None = None,
         print_log_on_error: bool | None = None,
+        default_open_kwargs: dict[str, Any] | None = None,
     ):
         """Change intake-esgf configuration options.
 
@@ -149,6 +157,9 @@ class Config(dict):
             Enable to print the session log when a DatasetLoadError is
             encountered. This is meant to be used in debugging CI to understand
             what is happening as tests fail.
+        default_open_kwargs: dict
+            The default key word arguments that are passed to
+            `xarray.open_mfdataset`.
 
         Examples
         --------
@@ -214,6 +225,8 @@ class Config(dict):
             self["slow_download_threshold"] = float(slow_download_threshold)
         if print_log_on_error is not None:
             self["print_log_on_error"] = bool(print_log_on_error)
+        if default_open_kwargs is not None:
+            self["default_open_kwargs"] = default_open_kwargs
         return self._unset(temp)
 
     def __getitem__(self, item):

--- a/intake_esgf/tests/test_catalog.py
+++ b/intake_esgf/tests/test_catalog.py
@@ -94,3 +94,34 @@ def test_download_summary(catalog):
 
 # def test_load_into_dsd():
 #    pass
+
+
+@pytest.mark.parametrize(
+    "kwargs,result",
+    [
+        (dict(), (1,) * 180),
+        (
+            dict(
+                data_vars="minimal",
+                coords="minimal",
+                compat="override",
+                chunks=dict(time=-1),
+            ),
+            (120, 60),
+        ),
+    ],
+)
+def test_open_kwargs(kwargs, result):
+    cat = intake_esgf.ESGFCatalog()
+    cat.search(
+        experiment_id="historical",
+        source_id="NorESM2-LM",
+        variable_id="tas",
+        frequency="mon",
+        file_start="2000-01",
+    ).remove_ensembles()
+    dsd = cat.to_dataset_dict(
+        add_measures=False,
+        open_kwargs=kwargs,
+    )
+    assert dsd["tas"]["tas"].chunksizes["time"] == result

--- a/intake_esgf/tests/test_catalog.py
+++ b/intake_esgf/tests/test_catalog.py
@@ -105,7 +105,7 @@ def test_download_summary(catalog):
                 data_vars="minimal",
                 coords="minimal",
                 compat="override",
-                chunks=dict(time=-1),
+                chunks="auto",
             ),
             (120, 60),
         ),

--- a/intake_esgf/tests/test_catalog.py
+++ b/intake_esgf/tests/test_catalog.py
@@ -95,23 +95,24 @@ def test_download_summary(catalog):
 # def test_load_into_dsd():
 #    pass
 
+KWARGS = dict(
+    data_vars="minimal",
+    coords="minimal",
+    compat="override",
+    chunks="auto",
+)
+
 
 @pytest.mark.parametrize(
-    "kwargs,result",
+    "conf,kwargs,result",
     [
-        (dict(), (1,) * 180),
-        (
-            dict(
-                data_vars="minimal",
-                coords="minimal",
-                compat="override",
-                chunks="auto",
-            ),
-            (120, 60),
-        ),
+        (dict(), None, (1,) * 180),
+        (dict(), KWARGS, (120, 60)),
+        (KWARGS, None, (120, 60)),
     ],
 )
-def test_open_kwargs(kwargs, result):
+def test_open_kwargs(conf, kwargs, result):
+    intake_esgf.conf.set(default_open_kwargs=conf)
     cat = intake_esgf.ESGFCatalog()
     cat.search(
         experiment_id="historical",


### PR DESCRIPTION
Addresses #166, how does this look @DominikStiller?

If this change solves your issue, I will add one further change: I would like to create a configure variable which stores default kwargs that we will pass to `open_mfdataset` if you don't specify any in `to_dataset_dict()`. This way, we do sensible things by default, but users can control the behavior.

I added a test which checks the chunks after specifying:

```python
dict(
    data_vars="minimal",
    coords="minimal",
    compat="override",
    chunks="auto",
)
```

I would make these the default kwargs as they seem good for the climate data we are serving. Do you agree? Any counter suggestion?

I did play with the `parallel=True` keyword but had some problems with it. I am inclined to let users enable that if they want for now.