### PR TITLE
Make it possible to pickle indices

### DIFF
--- a/intake_esgf/config.py
+++ b/intake_esgf/config.py
@@ -13,7 +13,7 @@ import intake_esgf.logging
 
 defaults = {
     "stac_indices": {
-        "api.stac.esgf.ceda.ac.uk": False,
+        # "api.stac.esgf.ceda.ac.uk": False,
         "data-challenge-04-discovery.api.stac.esgf-west.org": False,
         "data-challenge-06-discovery.api.stac.esgf-west.org": False,
     },

--- a/intake_esgf/core/globus.py
+++ b/intake_esgf/core/globus.py
@@ -46,7 +46,18 @@ class GlobusESGFIndex:
             index_id = GlobusESGFIndex.GLOBUS_INDEX_IDS[index_id]
         self.index_id = index_id
         self.client = SearchClient()
+        self.session = intake_esgf.conf.get_cached_session()
         self.logger = logging.getLogger(intake_esgf.logging.NAME)
+
+    def __getstate__(self) -> dict[str, Any]:
+        state = self.__dict__.copy()
+        state.pop("client")
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self.__dict__.update(state)
+        self.client = SearchClient()
+        self.session = intake_esgf.conf.get_cached_session()
 
     def __repr__(self):
         return self.repr
@@ -226,14 +237,13 @@ class GlobusESGFIndex:
 
 
 def variable_info(
-    session: requests.Session,
     query: str,
     project: str = "CMIP6",
 ) -> pd.DataFrame:
     """Return a dataframe with variable information from a query."""
     client = SearchClient()
-    client.transport.session = session
-    # first we populate a list of related veriables
+    client.transport.session = intake_esgf.conf.get_cached_session()
+    # first we populate a list of related variables
     uuid = GlobusESGFIndex.GLOBUS_INDEX_IDS["ESGF2-US-1.5-Catalog"]
     q = SearchQueryV1(
         q=query,

--- a/intake_esgf/core/solr.py
+++ b/intake_esgf/core/solr.py
@@ -42,8 +42,17 @@ class SolrESGFIndex:
         self.repr = f"SolrESGFIndex('{index_node}'{',distrib=True' if distrib else ''})"
         self.url = f"https://{index_node}"
         self.distrib = distrib
-        self.session = requests.Session()
+        self.session = intake_esgf.conf.get_cached_session()
         self.logger = logging.getLogger(intake_esgf.logging.NAME)
+
+    def __getstate__(self) -> dict[str, Any]:
+        state = self.__dict__.copy()
+        state.pop("session")
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self.__dict__.update(state)
+        self.session = intake_esgf.conf.get_cached_session()
 
     def __repr__(self):
         return self.repr

--- a/intake_esgf/core/stac.py
+++ b/intake_esgf/core/stac.py
@@ -11,6 +11,7 @@ import requests
 from pystac_client import Client, ItemSearch
 from pystac_client.stac_api_io import StacApiIO
 
+import intake_esgf
 import intake_esgf.base as base
 import intake_esgf.logging
 from intake_esgf.projects import projects
@@ -176,8 +177,17 @@ class STACESGFIndex:
     def __init__(self, url: str = "api.stac.ceda.ac.uk"):
         self.url = url
         self.cache: dict[str, Any] = {}
-        self.session = requests.Session()
+        self.session = intake_esgf.conf.get_cached_session()
         self.logger = logging.getLogger(intake_esgf.logging.NAME)
+
+    def __getstate__(self) -> dict[str, Any]:
+        state = self.__dict__.copy()
+        state.pop("session")
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self.__dict__.update(state)
+        self.session = intake_esgf.conf.get_cached_session()
 
     def __repr__(self):
         return f"STACESGFIndex('{self.url}')"

--- a/intake_esgf/tests/core/test_stac.py
+++ b/intake_esgf/tests/core/test_stac.py
@@ -1,3 +1,5 @@
+import pickle
+
 from intake_esgf.core import STACESGFIndex
 
 INDEX = STACESGFIndex("data-challenge-06-discovery.api.stac.esgf-west.org")
@@ -14,3 +16,12 @@ def test_search():
     assert len(df) == 2
     infos = INDEX.get_file_info(df["id"].to_list())
     assert len(infos) == 2
+
+
+def test_pickle() -> None:
+    index = INDEX
+    pickled = pickle.dumps(index)
+    unpickled = pickle.loads(pickled)
+    assert repr(index) == repr(unpickled)
+    assert str(index.session) == str(unpickled.session)
+    assert index.logger == unpickled.logger


### PR DESCRIPTION
`CachedSession` objects cannot be deepcopied or pickled (https://github.com/requests-cache/requests-cache/issues/707) because their state cannot be reliably restored in general. Because the cache is configured through the intake-esgf configuration, I think we can reliably restore the CachedSession object from the configuration for intake-esgf.

This makes it possible to `copy.deepcopy` and `pickle` indices, which avoids various issues we're currently seeing with using intake-esgf from ESMValTool (https://github.com/ESMValGroup/ESMValCore/issues/2989 and the workaround implemented [here](https://github.com/ESMValGroup/ESMValCore/blob/e926bc39e75355451e8260749333078d91c00040/esmvalcore/io/intake_esgf.py#L123-L138)). 