### PR TITLE
CHANGE: rework of STAC

### DIFF
--- a/intake_esgf/catalog.py
+++ b/intake_esgf/catalog.py
@@ -489,7 +489,7 @@ class ESGFCatalog:
             self._set_project()
         self.df["key"] = self.df.apply(
             lambda row: separator.join(
-                [row[f] for f in self.project.master_id_facets()]
+                [str(row[f]) for f in self.project.master_id_facets()]
             ),
             axis=1,
         )

--- a/intake_esgf/config.py
+++ b/intake_esgf/config.py
@@ -13,9 +13,9 @@ import intake_esgf.logging
 
 defaults = {
     "stac_indices": {
-        # "api.stac.esgf.ceda.ac.uk": False,
-        "data-challenge-04-discovery.api.stac.esgf-west.org": False,
+        "api.stac.esgf.ceda.ac.uk": False,
         "data-challenge-06-discovery.api.stac.esgf-west.org": False,
+        "integration-testing.api.stac.esgf-west.org": False,
     },
     "globus_indices": {
         "ESGF2-US-1.5-Catalog": True,

--- a/intake_esgf/config.py
+++ b/intake_esgf/config.py
@@ -14,8 +14,7 @@ import intake_esgf.logging
 defaults = {
     "stac_indices": {
         "api.stac.esgf.ceda.ac.uk": False,
-        "data-challenge-06-discovery.api.stac.esgf-west.org": False,
-        "integration-testing.api.stac.esgf-west.org": False,
+        "discovery.integration.esgf-west.org": False,
     },
     "globus_indices": {
         "ESGF2-US-1.5-Catalog": True,

--- a/intake_esgf/core/stac.py
+++ b/intake_esgf/core/stac.py
@@ -7,8 +7,7 @@ from pathlib import Path
 from typing import Any
 
 import pandas as pd
-import requests
-from pystac_client import Client, ItemSearch
+from pystac_client import Client
 from pystac_client.stac_api_io import StacApiIO
 
 import intake_esgf
@@ -16,114 +15,96 @@ import intake_esgf.base as base
 import intake_esgf.logging
 from intake_esgf.projects import projects
 
-# the stac extension additions that need `properties.cmip6:` prepended
-CMIP6_PREPENDS = [
-    "activity_id",
-    "cf_standard_name",
-    "citation_url",
-    "data_specs_version",
-    "experiment_id",
-    "experiment_title",
-    "frequency",
-    "further_info_url",
-    "grid",
-    "grid_label",
-    "institution_id",
-    "member_id",
-    "nominal_resolution",
-    "product",
-    "realm",
-    "source_id",
-    "source_type",
-    "table_id",
-    "variable",
-    "variable_id",
-    "variable_long_name",
-    "variable_units",
-    "variant_label",
-]
 
-
-def _search_facet_fixes(**search_facets: Any) -> dict[str, Any]:
+def _get_endpoint_collections(client: Client) -> list[str]:
     """
-    Make changes to the search facets based on STAC differences.
+    Return the collections of a client.
     """
-    # There is no such thing as Dataset/File 'types'
-    if "type" in search_facets:
-        search_facets.pop("type")
-    return search_facets
+    collection_search = client.collection_search()
+    collections = [
+        col["id"]
+        for page in collection_search.pages_as_dicts()
+        for col in page["collections"]
+    ]
+    return collections
 
 
-def _pre_search_hacks(**search_facets: Any) -> dict[str, Any]:
-    # The dc06 index uses variable and not variable_id
-    if "variable_id" in search_facets:
-        search_facets["variable"] = search_facets.pop("variable_id")
-    return search_facets
+def _get_collection_queryables(client: Client, project: str) -> list[str]:
+    """
+    Return the queryables of the client's collection.
+
+    Note
+    ----
+    Ultimately we hope to be able to get this information from the /queryables
+    endpoint of the catalog/collection. For the moment we write this function
+    and can switch the implementation later if/when this capability is
+    implemented.
+    """
+    items = client.search(collections=project, max_items=1).item_collection_as_dict()
+    if not items["features"]:
+        raise ValueError(f"No queryables for {project=}")
+    queryables = [prop for prop in items["features"][0]["properties"]]
+    return queryables
 
 
-def _post_search_hacks(
-    row: dict[str, Any], properties: dict[str, Any]
+def _fix_facets(
+    search_facets: dict[str, Any], project: str, queryables: list[str]
 ) -> dict[str, Any]:
-    # activity_drs is not in the extension
-    if "cmip6:activity_id" in properties:
-        row["activity_drs"] = properties["cmip6:activity_id"]
-    # The dc06 index uses variable and not variable_id
-    if "cmip6:variable" in properties:
-        row["variable_id"] = properties["cmip6:variable"]
-    # mip_era is not in the extension
-    row["mip_era"] = row["project"]
-    return row
-
-
-def search_cmip6(
-    session: requests.Session,
-    base_url: str,
-    items_per_page: int = 100,
-    **search_facets: Any,
-) -> ItemSearch:
     """
-    Returns a STAC client item search filtered by the search facets.
+    Transform the traditional search facets for a given project into
+    STAC-compliant facets.
 
-    Parameters
-    ----------
-    session:
-        The requests session to use for the STAC API.
-    base_url : str
-        The URL of the STAC API.
-    items_per_page : int, optional
-        The number of items to return per page.
-    **search_facets : str, list[str]
-        The traditional search facts expressed as additional keyword arguments,
-        for example `variable_id=['tas','pr']` or `source_id='UKESM1-0-LL'`.
-
-    Returns
-    -------
-    ItemSearch
-        The STAC search results.
+    Note
+    ----
+    1. They should be prepended with `properties` unless not querying in the
+       properies. At the moment, I am not sure users will do this. FIX.
+    2. If part of the project's extension, they should also be prepended with
+       `project:`
     """
-    # Create a filter using Common Query Language 2
+    project_prepends = [
+        q.split(":")[-1] for q in queryables if q.startswith(f"{project.lower()}:")
+    ]
+    search_facets = {
+        f"{project.lower() + ':' if key in project_prepends else ''}{key}": value
+        for key, value in search_facets.items()
+    }
+    not_valid = set(search_facets) - set(queryables)
+    if not_valid:
+        possible = [q.replace(f"{project.lower()}:", "") for q in queryables]
+        raise ValueError(
+            f"Some of your search criteria {not_valid=} are not supported in this {project=}. These are {possible=}."
+        )
+    search_facets = {
+        f"properties.{key}": value if isinstance(value, list) else [value]
+        for key, value in search_facets.items()
+    }
+    return search_facets
+
+
+def _search_facets_to_cql_filter(
+    search_facets: dict[str, Any], project: str, queryables: list[str]
+) -> dict[str, Any]:
+    """
+    Convert traditional search facets to a STAC filter.
+
+    Note
+    ----
+    STAC extensions require prepending additional properties with a namespace.
+    This makes sense in a world where you need to be able to search across
+    projects, but in our case is not needed.
+    """
+    search_facets = _fix_facets(search_facets, project, queryables)
     cql_filter = {
         "op": "and",
         "args": [
             {
                 "op": "in",
-                "args": [
-                    {
-                        "property": f"properties.{'cmip6:' if facet in CMIP6_PREPENDS else ''}{facet}"
-                    },
-                    facet_values if isinstance(facet_values, list) else [facet_values],
-                ],
+                "args": [{"property": facet}, facet_values],
             }
             for facet, facet_values in search_facets.items()
         ],
     }
-    # Initialize the client and search
-    stac_io = StacApiIO()
-    stac_io.session = session
-    results = Client.open(base_url, stac_io=stac_io).search(
-        collections="CMIP6", limit=items_per_page, filter=cql_filter
-    )
-    return results
+    return cql_filter
 
 
 def _get_content_path(url: str, project: str) -> Path:
@@ -195,18 +176,29 @@ class STACESGFIndex:
     def search(self, **search) -> pd.DataFrame:
         response_time = time.time()
 
-        # only for CMIP6 for now
+        # Intercept some options, some have special handling, others aren't used
         limit = search.pop("limit") if "limit" in search else 100
         project = search.pop("project") if "project" in search else "CMIP6"
-        if project.lower() != "cmip6":
-            raise ValueError("STAC index only for CMIP6")
+        _ = search.pop("type") if "type" in search else ""
 
-        # add some default facets if not given
-        search = _search_facet_fixes(**search)
-        search = _pre_search_hacks(**search)
-        items = search_cmip6(self.session, f"https://{self.url}", limit, **search)
+        # Initialize the client
+        stac_io = StacApiIO()
+        stac_io.session = self.session
+        client = Client.open(f"https://{self.url}", stac_io=stac_io)
 
-        # what facets do we expect?
+        # Ensure there is something to find
+        collections = _get_endpoint_collections(client)
+        if project not in collections:
+            response_time = time.time() - response_time
+            self.logger.info(f"└─{self} project not found {response_time=:.2f}")
+            return pd.DataFrame()
+
+        # Form the filter and search
+        queryables = _get_collection_queryables(client, project)
+        cql_filter = _search_facets_to_cql_filter(search, project, queryables)
+        items = client.search(collections=project, limit=limit, filter=cql_filter)
+
+        # What facets do we expect in the output?
         facets = (
             [
                 "project",
@@ -215,16 +207,20 @@ class STACESGFIndex:
             + intake_esgf.conf["additional_df_cols"]
         )
 
-        # populate the dataframe with hacks
+        # Populate the dataframe
         dfs = []
         for page in items.pages_as_dicts():
             for item in page["features"]:
                 properties = item["properties"]
                 row = {}
                 for col in facets:
-                    lookup = f"cmip6:{col}" if col in CMIP6_PREPENDS else col
+                    if col in queryables:
+                        lookup = col
+                    elif f"cmip6:{col}" in queryables:
+                        lookup = f"cmip6:{col}"
+                    else:
+                        lookup = ""  # Not in there, just skip
                     row[col] = properties[lookup] if lookup in properties else None
-                row = _post_search_hacks(row, properties)
                 # to make STAC consistent with other index types
                 row["data_node"] = self.url
                 row["id"] = f"{item['id']}|{row['data_node']}"
@@ -236,7 +232,7 @@ class STACESGFIndex:
                         for key, val in row.items()
                     }
                 )
-                self.cache[row["id"]] = item
+                self.cache[str(row["id"])] = item
 
         df = pd.DataFrame(dfs)
         response_time = time.time() - response_time

--- a/intake_esgf/core/stac.py
+++ b/intake_esgf/core/stac.py
@@ -23,7 +23,7 @@ def _get_endpoint_collections(client: Client) -> list[str]:
     """
     collection_search = client.collection_search()
     collections = [
-        col["id"]
+        col["title"]
         for page in collection_search.pages_as_dicts()
         for col in page["collections"]
     ]

--- a/intake_esgf/core/stac.py
+++ b/intake_esgf/core/stac.py
@@ -3,6 +3,7 @@
 import logging
 import re
 import time
+import warnings
 from pathlib import Path
 from typing import Any
 
@@ -155,7 +156,7 @@ def _parse_file_daterange(info: dict[str, Any]) -> dict[str, Any]:
 
 
 class STACESGFIndex:
-    def __init__(self, url: str = "api.stac.ceda.ac.uk"):
+    def __init__(self, url: str = "api.stac.esgf.ceda.ac.uk"):
         self.url = url
         self.cache: dict[str, Any] = {}
         self.session = intake_esgf.conf.get_cached_session()
@@ -199,11 +200,12 @@ class STACESGFIndex:
         items = client.search(collections=project, limit=limit, filter=cql_filter)
 
         # What facets do we expect in the output?
+        lower_project = project.lower()
         facets = (
             [
                 "project",
             ]
-            + projects[project.lower()].master_id_facets()
+            + projects[lower_project].master_id_facets()
             + intake_esgf.conf["additional_df_cols"]
         )
 
@@ -216,9 +218,12 @@ class STACESGFIndex:
                 for col in facets:
                     if col in queryables:
                         lookup = col
-                    elif f"cmip6:{col}" in queryables:
-                        lookup = f"cmip6:{col}"
+                    elif f"{lower_project}:{col}" in queryables:
+                        lookup = f"{lower_project}:{col}"
                     else:
+                        warnings.warn(
+                            f"Expected column '{col}' not found in response from {self.url}"
+                        )
                         lookup = ""  # Not in there, just skip
                     row[col] = properties[lookup] if lookup in properties else None
                 # to make STAC consistent with other index types

--- a/intake_esgf/core/stac.py
+++ b/intake_esgf/core/stac.py
@@ -72,7 +72,7 @@ def _fix_facets(
     not_valid = set(search_facets) - set(queryables)
     if not_valid:
         possible = [q.replace(f"{project.lower()}:", "") for q in queryables]
-        raise ValueError(
+        warnings.warn(
             f"Some of your search criteria {not_valid=} are not supported in this {project=}. These are {possible=}."
         )
     search_facets = {

--- a/intake_esgf/core/stac.py
+++ b/intake_esgf/core/stac.py
@@ -108,10 +108,17 @@ def _search_facets_to_cql_filter(
     return cql_filter
 
 
-def _get_content_path(url: str, project: str) -> Path:
+def _get_content_path(asset: dict[str, Any], project: str) -> Path:
     """
-    Return the local file path parsed from a https url.
+    Return the local file path.
     """
+    # This should be in ESGF STAC entries...
+    if "file:local_path" in asset:
+        return Path(asset["file:local_path"])
+    # ...but let's not count on it.
+    url = asset.get("href")
+    if url is None:
+        raise ValueError(f"Asset does not contain 'href' {asset=}")
     match = re.search(rf".*({project}.*.nc)|.*", url)
     if not match:
         raise ValueError(f"Could not parse out the path from {url}")
@@ -263,8 +270,8 @@ class STACESGFIndex:
                 if not asset["description"] == "HTTPServer Link":
                     continue
 
-                url = str(asset["href"])
-                path = _get_content_path(asset["href"], "CMIP6")
+                # Where do we put this file?
+                path = _get_content_path(asset, item["properties"]["project"])
 
                 # We could need to append to an existing location
                 if str(path) in infos:
@@ -276,7 +283,7 @@ class STACESGFIndex:
                 info["dataset_id"] = dataset_id
                 if "HTTPServer" not in info:
                     info["HTTPServer"] = []
-                info["HTTPServer"] += [url]
+                info["HTTPServer"] += [str(asset["href"])]
                 info["path"] = path
 
                 # Parse out information

--- a/intake_esgf/core/stac.py
+++ b/intake_esgf/core/stac.py
@@ -14,6 +14,7 @@ from pystac_client.stac_api_io import StacApiIO
 import intake_esgf
 import intake_esgf.base as base
 import intake_esgf.logging
+from intake_esgf.exceptions import NoSearchResults
 from intake_esgf.projects import projects
 
 
@@ -43,7 +44,7 @@ def _get_collection_queryables(client: Client, project: str) -> list[str]:
     """
     items = client.search(collections=project, max_items=1).item_collection_as_dict()
     if not items["features"]:
-        raise ValueError(f"No queryables for {project=}")
+        raise NoSearchResults()
     queryables = [prop for prop in items["features"][0]["properties"]]
     return queryables
 
@@ -57,10 +58,7 @@ def _fix_facets(
 
     Note
     ----
-    1. They should be prepended with `properties` unless not querying in the
-       properies. At the moment, I am not sure users will do this. FIX.
-    2. If part of the project's extension, they should also be prepended with
-       `project:`
+    If part of the project's extension, they should be prepended with `project:`
     """
     project_prepends = [
         q.split(":")[-1] for q in queryables if q.startswith(f"{project.lower()}:")
@@ -76,7 +74,7 @@ def _fix_facets(
             f"Some of your search criteria {not_valid=} are not supported in this {project=}. These are {possible=}."
         )
     search_facets = {
-        f"properties.{key}": value if isinstance(value, list) else [value]
+        f"{key}": value if isinstance(value, list) else [value]
         for key, value in search_facets.items()
     }
     return search_facets
@@ -84,7 +82,7 @@ def _fix_facets(
 
 def _search_facets_to_cql_filter(
     search_facets: dict[str, Any], project: str, queryables: list[str]
-) -> dict[str, Any]:
+) -> dict[str, Any] | None:
     """
     Convert traditional search facets to a STAC filter.
 
@@ -95,6 +93,8 @@ def _search_facets_to_cql_filter(
     projects, but in our case is not needed.
     """
     search_facets = _fix_facets(search_facets, project, queryables)
+    if not search_facets:
+        return None
     cql_filter = {
         "op": "and",
         "args": [
@@ -168,6 +168,7 @@ class STACESGFIndex:
         self.cache: dict[str, Any] = {}
         self.session = intake_esgf.conf.get_cached_session()
         self.logger = logging.getLogger(intake_esgf.logging.NAME)
+        self.last_project: str | None = None
 
     def __getstate__(self) -> dict[str, Any]:
         state = self.__dict__.copy()
@@ -187,6 +188,7 @@ class STACESGFIndex:
         # Intercept some options, some have special handling, others aren't used
         limit = search.pop("limit") if "limit" in search else 100
         project = search.pop("project") if "project" in search else "CMIP6"
+        self.last_project = project
         _ = search.pop("type") if "type" in search else ""
 
         # Initialize the client
@@ -271,7 +273,7 @@ class STACESGFIndex:
                     continue
 
                 # Where do we put this file?
-                path = _get_content_path(asset, item["properties"]["project"])
+                path = _get_content_path(asset, str(self.last_project))
 
                 # We could need to append to an existing location
                 if str(path) in infos:

--- a/intake_esgf/projects.py
+++ b/intake_esgf/projects.py
@@ -427,6 +427,54 @@ class WrPMIP(ESGFProject):
         return "grid_label"
 
 
+class CMIP7(ESGFProject):
+    def __init__(self):
+        self.facets = [
+            "drs_specs",
+            "project",
+            "activity_id",
+            "institution_id",
+            "source_id",
+            "experiment_id",
+            "variant_label",
+            "region",
+            "variable_id",
+            "variable_branding_suffix",
+            "grid_label",
+            "version",
+        ]
+
+    def master_id_facets(self) -> list[str]:
+        return self.facets[:-1]
+
+    def id_facets(self) -> list[str]:
+        return self.facets
+
+    def relaxation_facets(self) -> list[str]:
+        return [
+            "variable_branding_suffix",
+            "variant_label",
+            "experiment_id",
+            "activity_id",
+            "institution_id",
+        ]
+
+    def variable_description_facets(self) -> list[str]:
+        return ["variable_id", "variable_branding_suffix"]
+
+    def variable_facet(self) -> str:
+        return "variable_id"
+
+    def model_facet(self) -> str:
+        return "source_id"
+
+    def variant_facet(self) -> str:
+        return "variant_label"
+
+    def grid_facet(self) -> str | None:
+        return "grid_label"
+
+
 projects = {
     "cmip6": CMIP6(),
     "cmip5": CMIP5(),
@@ -437,6 +485,7 @@ projects = {
     "cmip6plus": CMIP6Plus(),
     "e3sm": e3sm(),
     "wrpmip": WrPMIP(),
+    "cmip7": CMIP7(),
 }
 
 

--- a/intake_esgf/tests/core/test_init.py
+++ b/intake_esgf/tests/core/test_init.py
@@ -5,13 +5,14 @@ from requests_cache import CachedSession
 
 import intake_esgf
 from intake_esgf import ESGFCatalog
+from intake_esgf.exceptions import NoSearchResults
 
 
 @pytest.mark.parametrize(
     "index_type",
     [
         "globus",
-        "stac",
+        pytest.param("stac", marks=pytest.mark.xfail(raises=NoSearchResults)),
         pytest.param("solr", marks=pytest.mark.solr),
     ],
 )

--- a/intake_esgf/tests/core/test_init.py
+++ b/intake_esgf/tests/core/test_init.py
@@ -28,6 +28,7 @@ def test_search_is_cached(index_type, tmp_path):
             )
 
     facets = {
+        "project": "CMIP6",
         "experiment_id": ["historical"],
         "source_id": ["CanESM5"],
         "variable_id": ["tas"],

--- a/intake_esgf/tests/core/test_stac.py
+++ b/intake_esgf/tests/core/test_stac.py
@@ -1,25 +1,90 @@
 import pickle
 
+import pytest
+
 from intake_esgf.core import STACESGFIndex
+from intake_esgf.exceptions import NoSearchResults
 
-INDEX = STACESGFIndex("data-challenge-06-discovery.api.stac.esgf-west.org")
+# INDEX = STACESGFIndex("discovery.integration.esgf-west.org")
 
 
-def test_search():
-    df = INDEX.search(
-        experiment_id="historical",
-        source_id="BCC-ESM1",
-        variable_id=["tas", "pr"],
-        variant_label="r1i1p1f1",
-        frequency="mon",
+@pytest.fixture
+def ceda():
+    return STACESGFIndex("api.stac.esgf.ceda.ac.uk")
+
+
+@pytest.fixture
+def west():
+    return STACESGFIndex("discovery.integration.esgf-west.org")
+
+
+def test_search_cmip6_west(west):
+    df = west.search(
+        project="CMIP6",
+        experiment_id="amip",
+        source_id="E3SM-1-0",
+        variable_id="tas",
     )
-    assert len(df) == 2
-    infos = INDEX.get_file_info(df["id"].to_list())
+    assert len(df) == 1
+    infos = west.get_file_info(df["id"].to_list())
+    assert len(infos) == 6
+
+
+def test_search_cmip7_west(west):
+    df = west.search(
+        project="CMIP7",
+        experiment_id="historical",
+        source_id="CanESM5-1",
+        variable_id="tas",
+    )
+    assert len(df) == 1
+    infos = west.get_file_info(df["id"].to_list())
     assert len(infos) == 2
 
 
-def test_pickle() -> None:
-    index = INDEX
+def test_search_cmip6plus_west(west):
+    df = west.search(
+        project="CMIP6Plus",
+        experiment_id="hist-lu",
+        source_id="HadGEM3-GC31-LL",
+        variable_id="areacella",
+    )
+    assert len(df) == 1
+    infos = west.get_file_info(df["id"].to_list())
+    assert len(infos) == 1
+
+
+@pytest.mark.xfail(raises=ValueError)
+def test_search_cmip6_ceda(ceda):
+    # This test should only return 1 item but because their CMIP6 is incorrectly published, returns many
+    df = ceda.search(
+        project="CMIP6",
+        experiment_id="dcppA-hindcast",
+        member_id="s2020-r1i1p1f2",
+        source_id="HadGEM3-GC31-MM",
+        variable_id="tasmax",
+    )
+    if len(df) != 1:
+        raise ValueError(f"Data is erroneously published on CEDA, {len(df)=} != 1")
+    infos = ceda.get_file_info(df["id"].to_list())
+    if len(infos) != 12:
+        raise ValueError(f"Data is erroneously published on CEDA, {len(infos)=} != 12")
+
+
+@pytest.mark.parametrize("project", ["CMIP6Plus", "CMIP7"])
+@pytest.mark.xfail(raises=NoSearchResults)
+def test_search_ceda_fails(ceda, project):
+    # Nothing is published in these so they should fail. Wh
+    df = ceda.search(
+        project=project,
+    )
+    assert len(df) == 0
+    infos = ceda.get_file_info(df["id"].to_list())
+    assert len(infos) == 0
+
+
+def test_pickle(ceda) -> None:
+    index = ceda
     pickled = pickle.dumps(index)
     unpickled = pickle.loads(pickled)
     assert repr(index) == repr(unpickled)


### PR DESCRIPTION
I expect this to be the final form of the intake-esgf stac index type. This rework uses the STAC catalog itself to check that the user's search facets are part of the list of queryable properties. 

- Our catalogs do not yet implement the `/queryable` endpoint (neither for collections) and thus instead we query a single item (cached), parse the properties, and return this as the queryables. 
- We currently default to a test STAC catalog that does not use the correct STAC extension (it uses `variable` and not `variable_id` for CMIP6 and has other issues). This will fail tests until this is fixed or we have a better sample.
- CEDA's test deployment has reverted to lowercase `cmip6` so it works but is not compatible with the other CMIP6 sources. 
- You can search for `obs4MIPs` except the current STAC catalog reports the `obs4MIPS` collection but publishes the correct name. This inconsistency prevents this capability for now.

In theory this PR means we are CMIP7 ready, but without consistent catalogs, this is a challenge. I am not hacking intake-esgf anymore for consistency mistakes. It just won't work until things are fixed :D